### PR TITLE
Downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,25 @@
-Usage:
-1. [Download your Twitter archive](https://twitter.com/settings/download_your_data) (Settings > Your account > Download an archive of your data)
-2. Unzip to a folder
-3. Open a command-prompt in that folder
-4. `python parser.py`
-
-Features:
+### Features:
 - Outputs as markdown with embedded images and links
 - Replaces t.co URLs with their original versions
+- Downloads full sized versions of images
 - Copies used images to an output folder, to allow them to be moved to a new home
 
-TODO:
+### TODO:
 - Output as Jekyll markdown files
 - Output as HTML files
 - Embed videos as HTML snippets in the markdown (currently just the thumbnail is shown)
+
+### Pre-requisites:
+
+- [python 3](https://www.python.org)
+  Note that macOS does _not_ ship with python 3 installed.
+- the `requests` package
+  install with `pip install requests`
+
+### Usage:
+
+1. [Download your Twitter archive](https://twitter.com/settings/download_your_data) (Settings > Your account > Download an archive of your data)
+2. Unzip to a folder
+3. Open a command-prompt in that folder
+4. `python path/to/parser.py`
+  note: depending on how python was installed on your system this may be `python3 path/to/parser.py`


### PR DESCRIPTION
### 1st a little fix:   
corrects the folder name for images. `tweet_data` should be `tweets_data`

### 2nd: 
downloads the full size version of the image and uses that in the markdown url, if successful.  Otherwise just uses the one that came in the archive.  A small percentage of images seem to violate the naming convention, or something, and aren't downloaded as a result. 

note: I've added in a 0.75 delay after downloading an image just to, hopefully, appease any algorithm that's trying to prevent DOSing or similar abuse. Seems to work. 

### 3rd: 
updates README to make the features the first things people see, and adds some notes for non-python geeks. 