### PR TITLE
added in the logic to split out by yyyy-mm

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -125,13 +125,36 @@ def main():
 
     # Sort tweets with oldest first
     tweets_markdown.sort(key=lambda tup: tup[0])
-    tweets_markdown = [md for t,md in tweets_markdown] # discard timestamps
-
-    # Save as one large markdown file
-    all_tweets = '\n----\n'.join(tweets_markdown)
+    # here begins my janky hackery to get this to output into yyyy-mm.md files
+    global lastyear
+    global all_tweets
+    global lastmonth
+    lastyear = 2006
+    lastmonth = 1
+    all_tweets = ""
+    for t,md in tweets_markdown:
+        dt = datetime.datetime.fromtimestamp(t)
+        currentyear = dt.year
+        currentmonth = dt.month
+        if (currentmonth != lastmonth ):
+            if (currentyear != lastyear):
+                output_filename = str(lastyear)+'-'+str(lastmonth)+'.md'
+                lastyear = currentyear
+            else:
+                output_filename = str(currentyear)+'-'+str(lastmonth)+'.md'
+            if (all_tweets != ""):
+                print('writing out to ' + output_filename)
+                with open(output_filename, 'w', encoding='utf-8') as f:
+                    f.write(all_tweets)
+            all_tweets = '\n----\n'+md
+            lastmonth = currentmonth
+        else:
+            all_tweets += '\n----\n'+md
+    output_filename = str(currentyear)+'-'+str(currentmonth)+'.md'
+    print('writing out to ' + output_filename)
     with open(output_filename, 'w', encoding='utf-8') as f:
         f.write(all_tweets)
-    print(f'Wrote to {output_filename}, which embeds images from {output_media_folder_name}')
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Looping logic is probably only marginally pythonic.

Basically, it sets a couple of globals (sorry!) for year & month, and then does a fairly straightforward "did the month or year change" while looping through the array of tweets (which had just been sorted in the previous step).

A little bit of guardrailing around not outputting empty files, and that's about it. 

It's actually reasonably performant -- at least for my 170k tweet archive.

Due to the way I'm converting timestamps back to datetime objects to compare month and year (i.e. lazily, so that they're TZ-unaware), depending on your TZ, you can wind up with a stray tweet from the next month at the very end of the previous month's markdown file. I hate datetime math more than anything else in the world, so I've opted to acknowledge this & not fix it :)