### PR TITLE
Add empty lines around horizontal rule

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -131,7 +131,7 @@ def main():
     for timestamp, md in tweets_markdown:
         dt = datetime.datetime.fromtimestamp(timestamp)
         filename = f'tweets_{dt.year}-{dt.month:02}.md'
-        tweets_by_month[filename] += md + '\n----\n'
+        tweets_by_month[filename] += md + '\n\n----\n\n'
 
     # Write into files
     for filename, md in tweets_by_month.items():


### PR DESCRIPTION
Minor change, but without an empty line before the horizontal rule, the "Originally on Twitter" line will be interpreted as a heading.

See, for example, https://www.markdownguide.org/basic-syntax/#horizontal-rule-best-practices which recommends using a blank line either side of a horizontal rule.