### PR TITLE
Add pyproject.toml to make project installable via pipx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+__pycache__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "twitter-archive-parser"
+version = "0.1.0"
+license = { text = "GPL version 3 or later"}
+description = "Python code to parse a Twitter archive and output in various ways"
+authors = [{name="Tim Hutton"}]
+readme = "README.md"
+dependencies = [
+    "requests",
+]
+
+[build-system]
+requires = ["setuptools >= 40.9.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["parser", "download_better_images"]
+namespaces = false
+
+[project.scripts]
+twitter-archive-parser = "parser:main"
+twitter-archive-download-better-images = "download_better_images:main"


### PR DESCRIPTION
See the following output:

```
pipx install git+https://github.com/jankatins/twitter-archive-parser.git@jan-make-installable
  installed package twitter-archive-parser 0.1.0, installed using Python 3.10.8
  These apps are now globally available
    - twitter-archive-download-better-images
    - twitter-archive-parser
done! ✨ 🌟 ✨
```

Closes: https://github.com/timhutton/twitter-archive-parser/issues/55