### PR TITLE
Improved decision on whether to download and/or overwrite media

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -213,18 +213,19 @@ def download_file_if_larger(url, filename, index, count, sleep_time):
             byte_size_after = int(res.headers['content-length'])
             if (byte_size_after != byte_size_before):
                 # Proceed with the full download
-                print(f'{pref}Downloading {url}...', end='\r')
-                with open(filename+'.tmp','wb') as f:
+                tmp_filename = filename+'.tmp'
+                print(f'{pref}Downloading {url}...            ', end='\r')
+                with open(tmp_filename,'wb') as f:
                     shutil.copyfileobj(res.raw, f)
                 post = f'{byte_size_after/2**20:.1f}MB downloaded'
                 width_before, height_before = imagesize.get(filename)
-                width_after, height_after = imagesize.get(filename+'.tmp')
+                width_after, height_after = imagesize.get(tmp_filename)
                 pixels_before, pixels_after = width_before * height_before, width_after * height_after
                 pixels_percentage_increase = 100.0 * (pixels_after - pixels_before) / pixels_before
 
                 if (width_before == -1 and height_before == -1 and width_after == -1 and height_after == -1):
                     # could not check size of both versions, probably a video or unsupported image format
-                    os.replace(filename+'.tmp', filename)
+                    os.replace(tmp_filename, filename)
                     bytes_percentage_increase = 100.0 * (byte_size_after - byte_size_before) / byte_size_before
                     logging.info(f'{pref}SUCCESS. New version is {bytes_percentage_increase:3.0f}% '
                                  f'larger in bytes (pixel comparison not possible). {post}')
@@ -235,7 +236,7 @@ def download_file_if_larger(url, filename, index, count, sleep_time):
                                  f'{width_before}*{height_before}px vs. {width_after}*{height_after}px. {post}')
                     return False, byte_size_after
                 elif (pixels_after >= pixels_before):
-                    os.replace(filename+'.tmp', filename)
+                    os.replace(tmp_filename, filename)
                     bytes_percentage_increase = 100.0 * (byte_size_after - byte_size_before) / byte_size_before
                     if (bytes_percentage_increase >= 0):
                         logging.info(f'{pref}SUCCESS. New version is {bytes_percentage_increase:3.0f}% larger in bytes ' 

--- a/parser.py
+++ b/parser.py
@@ -195,12 +195,14 @@ def download_file_if_larger(url, filename, index, count, sleep_time):
     """
     requests = import_module('requests')
     imagesize = import_module('imagesize')
+
+    pref = f'{index:3d}/{count:3d} {filename}: '
     # Sleep briefly, in an attempt to minimize the possibility of trigging some auto-cutoff mechanism
     if index > 1:
-        print(f'{index:3d}/{count:3d}: Sleeping...', end='\r')
+        print(f'{pref}Sleeping...', end='\r')
         time.sleep(sleep_time)
     # Request the URL (in stream mode so that we can conditionally abort depending on the headers)
-    print(f'{index:3d}/{count:3d}: Requesting headers for {url}...', end='\r')
+    print(f'{pref}Requesting headers for {url}...', end='\r')
     byte_size_before = os.path.getsize(filename)
     try:
         with requests.get(url, stream=True) as res:
@@ -209,9 +211,10 @@ def download_file_if_larger(url, filename, index, count, sleep_time):
             byte_size_after = int(res.headers['content-length'])
             if (byte_size_after != byte_size_before):
                 # Proceed with the full download
-                print(f'{index:3d}/{count:3d}: Downloading {url}...            ', end='\r')
+                print(f'{pref}Downloading {url}...', end='\r')
                 with open(filename+'.tmp','wb') as f:
                     shutil.copyfileobj(res.raw, f)
+                post = f'{byte_size_after/2**20:.1f}MB downloaded'
                 width_before, height_before = imagesize.get(filename)
                 width_after, height_after = imagesize.get(filename+'.tmp')
                 pixels_before, pixels_after = width_before * height_before, width_after * height_after
@@ -221,25 +224,28 @@ def download_file_if_larger(url, filename, index, count, sleep_time):
                     # could not check size of both versions, probably a video or unsupported image format
                     os.replace(filename+'.tmp', filename)
                     bytes_percentage_increase = 100.0 * (byte_size_after - byte_size_before) / byte_size_before
-                    logging.info(f'{index:3d}/{count:3d}: Success. New version is {bytes_percentage_increase:3.0f}% larger in bytes (pixel comparison not possible), {byte_size_after/2**20:.1f}MB downloaded, overwrote {filename}')
+                    logging.info(f'{pref}SUCCESS. New version is {bytes_percentage_increase:3.0f}% '
+                                 f'larger in bytes (pixel comparison not possible). {post}')
                     return True, byte_size_after
                 elif (width_before == -1 or height_before == -1 or width_after == -1 or height_after == -1):
                     # could not check size of one version, this should not happen (corrupted download?)
-                    logging.info(f'{index:3d}/{count:3d}: Skipped. Pixel size comparison inconclusive: {width_before}*{height_before}px vs. {width_after}*{height_after}px. {byte_size_after/2**20:.1f}MB downloaded, file is {filename}')
+                    logging.info(f'{pref}SKIPPED. Pixel size comparison inconclusive: '
+                                 f'{width_before}*{height_before}px vs. {width_after}*{height_after}px. {post}')
                     return False, byte_size_after
                 elif (pixels_after >= pixels_before):
                     os.replace(filename+'.tmp', filename)
                     bytes_percentage_increase = 100.0 * (byte_size_after - byte_size_before) / byte_size_before
-                    logging.info(f'{index:3d}/{count:3d}: Success. New version is {bytes_percentage_increase:3.0f}% larger in bytes and {pixels_percentage_increase:3.0f}% larger in pixels, {byte_size_after/2**20:.1f}MB downloaded, overwrote {filename}')
+                    logging.info(f'{pref}SUCCESS. New version is {bytes_percentage_increase:3.0f}% larger in bytes ' 
+                                 f'and {pixels_percentage_increase:3.0f}% larger in pixels. {post}')
                     return True, byte_size_after
                 else:
-                    logging.info(f'{index:3d}/{count:3d}: Skipped. Online version has {-pixels_percentage_increase:3.0f}% smaller pixel size than {filename}')
+                    logging.info(f'{pref}SKIPPED. Online version has {-pixels_percentage_increase:3.0f}% smaller pixel. {post}')
                     return True, byte_size_after
             else:
-                logging.info(f'{index:3d}/{count:3d}: Skipped.  Online version is same byte size, assuming same content as {filename}')
+                logging.info(f'{pref}SKIPPED. Online version is same byte size, assuming same content. Not downloaded.')
                 return True, 0
     except Exception as err:
-        logging.error(f"{index}/{count}: Fail. Media couldn't be retrieved: {url} Filename: {filename} Because: {err}")
+        logging.error(f"{pref}FAIL. Media couldn't be retrieved: {url} Filename: {filename} Because: {err}")
         return False, 0
 
 

--- a/parser.py
+++ b/parser.py
@@ -207,7 +207,9 @@ def download_file_if_larger(url, filename, index, count, sleep_time):
     try:
         with requests.get(url, stream=True) as res:
             if not res.status_code == 200:
-                raise Exception('Download failed')
+                # Try to get content of response as `res.text`. For twitter.com, this will be empty in most (all?) cases.
+                # It is successfully tested with error responses from other domains.
+                raise Exception(f'Download failed with status "{res.status_code} {res.reason}". Response content: "{res.text}"')
             byte_size_after = int(res.headers['content-length'])
             if (byte_size_after != byte_size_before):
                 # Proceed with the full download

--- a/parser.py
+++ b/parser.py
@@ -245,7 +245,7 @@ def download_file_if_larger(url, filename, index, count, sleep_time):
                 logging.info(f'{pref}SKIPPED. Online version is same byte size, assuming same content. Not downloaded.')
                 return True, 0
     except Exception as err:
-        logging.error(f"{pref}FAIL. Media couldn't be retrieved: {url} Filename: {filename} Because: {err}")
+        logging.error(f"{pref}FAIL. Media couldn't be retrieved from {url} because of exception: {err}")
         return False, 0
 
 

--- a/parser.py
+++ b/parser.py
@@ -235,11 +235,15 @@ def download_file_if_larger(url, filename, index, count, sleep_time):
                 elif (pixels_after >= pixels_before):
                     os.replace(filename+'.tmp', filename)
                     bytes_percentage_increase = 100.0 * (byte_size_after - byte_size_before) / byte_size_before
-                    logging.info(f'{pref}SUCCESS. New version is {bytes_percentage_increase:3.0f}% larger in bytes ' 
-                                 f'and {pixels_percentage_increase:3.0f}% larger in pixels. {post}')
+                    if (bytes_percentage_increase >= 0):
+                        logging.info(f'{pref}SUCCESS. New version is {bytes_percentage_increase:3.0f}% larger in bytes ' 
+                                    f'and {pixels_percentage_increase:3.0f}% larger in pixels. {post}')
+                    else:
+                        logging.info(f'{pref}SUCCESS. New version is actually {-bytes_percentage_increase:3.0f}% smaller in bytes ' 
+                                f'but {pixels_percentage_increase:3.0f}% larger in pixels. {post}')
                     return True, byte_size_after
                 else:
-                    logging.info(f'{pref}SKIPPED. Online version has {-pixels_percentage_increase:3.0f}% smaller pixel. {post}')
+                    logging.info(f'{pref}SKIPPED. Online version has {-pixels_percentage_increase:3.0f}% smaller pixel size. {post}')
                     return True, byte_size_after
             else:
                 logging.info(f'{pref}SKIPPED. Online version is same byte size, assuming same content. Not downloaded.')


### PR DESCRIPTION
I've made a lot of changes to `download_file_if_larger`. I'm sorry for mixing multiple changes into a single PR, but they evolved in parallel. Here's what this changes:

 * Only download file if `byte_size_after != byte_size_before` because it seems *very* unlikely that two versions with same file size are actually different
 * Download file even if it is smaller *in bytes*, because less bytes may encode more / better pixels, as pointed out in #51
 * After downloading, check image size *in pixels* and use downloaded file if `pixels_after >= pixels_before`
 * Reordered contents of log line: index / count, filename, result (uppercase), explanation, downloaded bytes
 * Less code repetition for log outputs by prefixes and postfixes into `pref` and `post`
 * On error, print `{err}` (not sure if this is the best way to get a meaningful message out of the exception)
 * some more code cleanup

I'm using [imagesize_py](https://github.com/shibukawa/imagesize_py) which can determine the pixel size without loading the whole image, and supports many image formats. If called on a video file, it would *probably* return `-1, -1` which I try to handle in my code. But since I never encountered a video with `byte_size_after != byte_size_before`, this did not occur anyway. I'm going to test this later.

The output format has changed a lot and now looks like this (shortened). At `14/79` there is an example of a file with smaller byte size, but larger pixel size. At `37/79` there is an example of a video, but the pixel size was not inspected.

```
[...]
frequent. This script may not work if your account is protected. You may want to set it to public
before starting the download.

OK to start downloading? [y/n]y
  1/ 79 media/1357031742197104640-EtOs3ASWgAUCHa_.jpg: SKIPPED. Online version is same byte size, assuming same content. Not downloaded.
  2/ 79 media/1343985634613075968-EqbLdKdXIA02fXl.jpg: SUCCESS. New version is  50% larger in bytes and  88% larger in pixels. 0.2MB downloaded
  3/ 79 media/1343962182770421760-Eqa1eakW8AYm8dZ.jpg: SUCCESS. New version is  13% larger in bytes and  14% larger in pixels. 0.1MB downloaded
  4/ 79 media/1343962170422403075-EqazVseXEAAYI6R.png: SKIPPED. Online version is same byte size, assuming same content. Not downloaded.
[...]
 14/ 79 media/1237779856546574338-ES15j3iX0AwmlHo.png: SUCCESS. New version is -56% larger in bytes and  30% larger in pixels. 0.3MB downloaded
[...]
 37/ 79 media/864232876539351040-uTWbzDlB_rr2kkh0.mp4: SKIPPED. Online version is same byte size, assuming same content. Not downloaded./vid/534x360/uTWbzDlB_rr2kkh0.mp4...
[...]
 79/ 79 media/1249726622888005635-EVfrvEmXsAAwlVL.jpg: SUCCESS. New version is 105% larger in bytes and 125% larger in pixels. 0.2MB downloaded

79 of 79 tested media files are known to be the best-quality available.

Total downloaded: 14.4MB = 0.01GB
Time taken: 85s
Wrote log to media/download_log.txt
In case you set your account to public before initiating the download, do not forget to protect it again.
```