### PR TITLE
Workaround for older Twitter archive tweet.js tweet objects

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -58,7 +58,8 @@ def extract_username(account_js_filename):
 def convert_tweet(tweet, username, archive_media_folder, output_media_folder_name,
                            tweet_icon_path, media_sources):
     """Converts a JSON-format tweet. Returns tuple of timestamp, markdown and HTML."""
-    tweet = tweet['tweet']
+    if 'tweet' in tweet.keys():
+        tweet = tweet['tweet']
     timestamp_str = tweet['created_at']
     timestamp = int(round(datetime.datetime.strptime(timestamp_str, '%a %b %d %X %z %Y').timestamp())) # Example: Tue Mar 19 14:05:17 +0000 2019
     body_markdown = tweet['full_text']


### PR DESCRIPTION
Older Twitter archives (I have one from 2019) seem to use an array of objects like so:
```
{
  "retweeted" : false,
  "source" : "<a href=\"http://twitter.com\" rel=\"nofollow\">Twitter Web Client</a>",
  "entities" : {
    "hashtags" : [ ],
    "symbols" : [ ],
    "user_mentions" : [ ],
    "urls" : [ ]
  },
  "display_text_range" : [ "0", "47" ],
  "favorite_count" : "5",
  "id_str" : "11948217481365XXXXX",
  "truncated" : false,
  "retweet_count" : "0",
  "id" : "119482174813653XXXX",
  "created_at" : "Thu Nov 14 03:37:58 +0000 2019",
  "favorited" : false,
  "full_text" : "example text",
  "lang" : "en"
}
```
However, the latest archives have a named `tweet` object, as I'm sure you're aware:
```
{
  "tweet": {
    "retweeted" : false,
    "source" : "<a href=\"http://twitter.com\" rel=\"nofollow\">Twitter Web Client</a>",
    "entities" : {
      "hashtags" : [ ],
      "symbols" : [ ],
      "user_mentions" : [ ],
      "urls" : [ ]
    },
    "display_text_range" : [ "0", "47" ],
    "favorite_count" : "5",
    "id_str" : "11948217481365XXXXX",
    "truncated" : false,
    "retweet_count" : "0",
    "id" : "119482174813653XXXX",
    "created_at" : "Thu Nov 14 03:37:58 +0000 2019",
    "favorited" : false,
    "full_text" : "example text",
    "lang" : "en"
  }
}
```
This just adds a workaround to the tweet dict access as that's the only actual bug I've encountered. As a side note, these old archives include media in zip files within the data folders. Maybe detection could be added for those.