### PR TITLE
Parse followers and following, output with handles where known.

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -332,7 +332,7 @@ def main():
     log_path = os.path.join(output_media_folder_name, 'download_log.txt')
     output_following_filename = 'following.txt'
     output_followers_filename = 'followers.txt'
-    unknown_user_URL = 'https://twitter.com/i/user/{}'
+    user_id_URL = 'https://twitter.com/i/user/{}'
 
     HTML = """\
 <!doctype html>
@@ -387,7 +387,8 @@ def main():
     for follow in following_json:
         if 'following' in follow and 'accountId' in follow['following']:
             id = follow['following']['accountId']
-            following.append(users[id].handle if id in users else unknown_user_URL.format(id))
+            handle = users[id].handle if id in users else '~unknown~handle~'
+            following.append(handle + ' ' + user_id_URL.format(id))
     following.sort()
     with open(output_following_filename, 'w', encoding='utf8') as f:
         for user in following:
@@ -399,7 +400,8 @@ def main():
     for follower in follower_json:
         if 'follower' in follower and 'accountId' in follower['follower']:
             id = follower['follower']['accountId']
-            followers.append(users[id].handle if id in users else unknown_user_URL.format(id))
+            handle = users[id].handle if id in users else '~unknown~handle~'
+            followers.append(handle + ' ' + user_id_URL.format(id))
     followers.sort()
     with open(output_followers_filename, 'w', encoding='utf8') as f:
         for user in followers:

--- a/parser.py
+++ b/parser.py
@@ -332,6 +332,7 @@ def main():
     log_path = os.path.join(output_media_folder_name, 'download_log.txt')
     output_following_filename = 'following.txt'
     output_followers_filename = 'followers.txt'
+    unknown_user_URL = 'https://twitter.com/i/user/{}'
 
     HTML = """\
 <!doctype html>
@@ -386,7 +387,7 @@ def main():
     for follow in following_json:
         if 'following' in follow and 'accountId' in follow['following']:
             id = follow['following']['accountId']
-            following.append(users[id].handle if id in users else '~unknown~user~' + id)
+            following.append(users[id].handle if id in users else unknown_user_URL.format(id))
     following.sort()
     with open(output_following_filename, 'w', encoding='utf8') as f:
         for user in following:
@@ -398,7 +399,7 @@ def main():
     for follower in follower_json:
         if 'follower' in follower and 'accountId' in follower['follower']:
             id = follower['follower']['accountId']
-            followers.append(users[id].handle if id in users else '~unknown~user~' + id)
+            followers.append(users[id].handle if id in users else unknown_user_URL.format(id))
     followers.sort()
     with open(output_followers_filename, 'w', encoding='utf8') as f:
         for user in followers:

--- a/parser.py
+++ b/parser.py
@@ -391,8 +391,7 @@ def main():
             following.append(handle + ' ' + user_id_URL.format(id))
     following.sort()
     with open(output_following_filename, 'w', encoding='utf8') as f:
-        for user in following:
-            f.write(user + '\n')
+        f.write('\n'.join(following))
 
     # Parse the followers
     followers = []
@@ -404,8 +403,7 @@ def main():
             followers.append(handle + ' ' + user_id_URL.format(id))
     followers.sort()
     with open(output_followers_filename, 'w', encoding='utf8') as f:
-        for user in followers:
-            f.write(user + '\n')
+        f.write('\n'.join(followers))
 
     # Sort tweets with oldest first
     tweets.sort(key=lambda tup: tup[0])

--- a/parser.py
+++ b/parser.py
@@ -330,6 +330,8 @@ def main():
     data_folder = os.path.join(input_folder, 'data')
     account_js_filename = os.path.join(data_folder, 'account.js')
     log_path = os.path.join(output_media_folder_name, 'download_log.txt')
+    output_following_filename = 'following.txt'
+    output_followers_filename = 'followers.txt'
 
     HTML = """\
 <!doctype html>
@@ -378,6 +380,30 @@ def main():
     print(f'Parsed {len(tweets)} tweets and replies by {username}.')
     print(f'Found {len(users)} user_id:handle mappings.')
 
+    # Parse the followings
+    following = []
+    following_json = read_json_from_js_file(os.path.join(data_folder, 'following.js'))
+    for follow in following_json:
+        if 'following' in follow and 'accountId' in follow['following']:
+            id = follow['following']['accountId']
+            following.append(users[id].handle if id in users else '~unknown~user~' + id)
+    following.sort()
+    with open(output_following_filename, 'w', encoding='utf8') as f:
+        for user in following:
+            f.write(user + '\n')
+
+    # Parse the followers
+    followers = []
+    follower_json = read_json_from_js_file(os.path.join(data_folder, 'follower.js'))
+    for follower in follower_json:
+        if 'follower' in follower and 'accountId' in follower['follower']:
+            id = follower['follower']['accountId']
+            followers.append(users[id].handle if id in users else '~unknown~user~' + id)
+    followers.sort()
+    with open(output_followers_filename, 'w', encoding='utf8') as f:
+        for user in followers:
+            f.write(user + '\n')
+
     # Sort tweets with oldest first
     tweets.sort(key=lambda tup: tup[0])
 
@@ -400,7 +426,7 @@ def main():
     with open(output_html_filename, 'w', encoding='utf-8') as f:
         f.write(HTML.format(all_html_string))
 
-    print(f'Wrote tweets to *.md and {output_html_filename}, with images and video embedded from {output_media_folder_name}')
+    print(f'Wrote tweets to *.md and {output_html_filename} and {output_following_filename} and {output_followers_filename}, with images and video embedded from {output_media_folder_name}')
 
     # Ask user if they want to try downloading larger images
     print(f"\nThe archive doesn't contain the original-size images. We can attempt to download them from twimg.com.")


### PR DESCRIPTION
This partially fixes #70 but not completely since we don't know many of the handles.

The output text files contain `<handle> https://twitter.com/i/user/<user_id>` where handle is `~unknown~handle~` where not known (sorted to the end). The user_id URLs should still work even if someone has changed their handle.

For my archive, user handles are known for 50% of the followings, and 12% of the followers.

When we have a way of retrieving more user_id:handle mappings then this output will improve.

On the suggested roadmap (from discussion in #6):
1. existing `convert_tweet()` function appends whatever id:handle connections it finds to a data structure of Users. <-- PR #76 
1. new functionality to parse DMs, using Users, output in some simple way
1. new functionality to parse followers/followings, using Users, output in some simple way <-- this PR
1. new functionality to do remote lookup on Users, to improve the output of the above

This targets the `handles` branch pending the merge of that PR.

Ping: @flauschzelle, @lenaschimmel, @press-rouch, @n1ckfg