### PR TITLE
Bugfix: avoid crashes when trying to read one-line (empty JSON) file

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -35,6 +35,10 @@ def read_json_from_js_file(filename):
     """Reads the contents of a Twitter-produced .js file into a dictionary."""
     with open(filename, 'r', encoding='utf8') as f:
         data = f.readlines()
+        # if the JSON has no real content, it can happen that the file is only one line long.
+        # in this case, return an empty dict to avoid errors while trying to read non-existing lines.
+        if len(data) <= 1:
+            return {}
         # convert js file to JSON: replace first line with just '[', squash lines into a single string
         prefix = '['
         if '{' in data[0]:


### PR DESCRIPTION
When trying to parse JSON from Twitter's JS format, but the JSON is an empty list, the parser would crash with an error in the JSON decoding. With this fix, the method just returns an empty dict instead, so checks for empty content can be made by the caller.

(An additional thought on this: it works for me like this with the empty dict, but I think the method should generally be returning a list instead of a dict? Because Twitter's JSON is (almost) always wrapped in a list at the highest level.)