### PR TITLE
Base feature: Download tweets which are missing or incomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ Flaws of the Twitter archive:
 
 Our script does the following:
 - Converts the tweets to [markdown](https://en.wikipedia.org/wiki/Markdown) and also HTML, with embedded images, videos and links.
-- Replaces t.co URLs with their original versions.
+- Replaces t.co URLs with their original versions (the ones that can be found in the archive).
 - Copies used images to an output folder, to allow them to be moved to a new home.
-- Will query Twitter for the missing user handles (checks with you first)
+- Will query Twitter for the missing user handles (checks with you first).
 - Converts DMs to markdown. Basic functionality for now, pending improvements.
 - Outputs lists of followers and following.
-- Afterwards, it asks if you want to try downloading the original size images.
+- Downloads the original size images (checks with you first).
 
 ### For advanced users:
 

--- a/parser.py
+++ b/parser.py
@@ -465,10 +465,11 @@ def parse_followers(data_folder, users, user_id_URL_template, output_followers_f
 
 
 def parse_direct_messages(data_folder, users, user_id_URL_template, output_dms_filename):
-    """Parse data_folder/direct-messages.js, write to output_followers_filename.
+    """Parse data_folder/direct-messages.js, write to output_dms_filename.
        Query Twitter API for the missing user handles, if the user agrees.
     """
     dms_markdown = ''
+    # Scan the DMs for missing user handles
     dms_json = read_json_from_js_file(os.path.join(data_folder, 'direct-messages.js'))
     dm_user_ids = set()
     for conversation in dms_json:

--- a/parser.py
+++ b/parser.py
@@ -86,6 +86,34 @@ def get_twitter_users(session, bearer_token, guest_token, user_ids):
             users[user["id_str"]] = user
     return users
 
+def get_tweets(session, bearer_token, guest_token, tweet_ids, include_user=True, include_alt_text=True):
+    """ Get the json metadata for a multiple tweets.
+    If include_user is False, you will only get a numerical id for the user."""
+    tweets = {}
+    remaining_tweet_ids = tweet_ids.copy()
+    while remaining_tweet_ids:
+        max_batch = 100
+        tweet_id_batch = remaining_tweet_ids[:max_batch]
+        tweet_id_list = ",".join(tweet_id_batch)
+        print(f"Download {len(tweet_id_batch)} tweets of {len(remaining_tweet_ids)} remaining...")
+        query_url = f"https://api.twitter.com/1.1/statuses/lookup.json?id={tweet_id_list}&tweet_mode=extended"
+        if not include_user:
+            query_url += "&trim_user=1"
+        if include_alt_text:
+            query_url += "&include_ext_alt_text=1"
+        response = session.get(query_url,
+                               headers={'authorization': f'Bearer {bearer_token}', 'x-guest-token': guest_token})
+        if response.status_code == 429:
+            # Rate limit exceeded - get a new token
+            guest_token = get_twitter_api_guest_token(session, bearer_token)
+            continue
+        if not response.status_code == 200:
+            raise Exception(f'Failed to get tweets: {response}')
+        response_json = json.loads(response.content)
+        for tweet in response_json:
+            tweets[tweet["id_str"]] = tweet
+        remaining_tweet_ids = remaining_tweet_ids[max_batch:]
+    return tweets
 
 def lookup_users(user_ids, users):
     """Fill the users dictionary with data from Twitter"""
@@ -134,10 +162,52 @@ def extract_username(account_js_filename):
     account = read_json_from_js_file(account_js_filename)
     return account[0]['account']['username']
 
+def collect_tweet_id(tweet):
+    if 'tweet' in tweet.keys():
+        tweet = tweet['tweet']
+    return tweet['id_str']
+
+
+def collect_tweet_references(tweet, known_tweet_ids, counts):
+    if 'tweet' in tweet.keys():
+        tweet = tweet['tweet']
+    tweet_ids = set()
+    # Collect quoted tweets
+    if 'entities' in tweet and 'urls' in tweet['entities']:
+        for url in tweet['entities']['urls']:
+            if 'url' in url and 'expanded_url' in url:
+                expanded_url = url['expanded_url']
+                matches = re.match(r'^https://twitter.com/([0-9A-Za-z_]*)/status/(\d+)$', expanded_url)
+                if (matches):
+                    #user_handle = matches[1]
+                    tweet_ids.add(matches[2])
+                    counts['quote'] += 1
+
+    # Collect previous tweets in conversation
+    if 'in_reply_to_status_id_str' in tweet:
+        if (tweet['in_reply_to_status_id_str'] in known_tweet_ids):
+            counts['known_reply'] += 1
+        else:
+            tweet_ids.add(tweet['in_reply_to_status_id_str'])
+            counts['reply'] += 1
+
+    # Collect retweets
+    if 'full_text' in tweet and tweet['full_text'].startswith('RT @'):
+        tweet_ids.add(tweet['id_str'])
+        counts['retweet'] += 1
+
+    # Collect tweets with media, which might lack alt text
+    # TODO we might filter for media which has "type" : "photo" because there is no alt text for videos
+    if 'entities' in tweet and 'media' in tweet['entities']:
+        tweet_ids.add(tweet['id_str'])
+        counts['media'] += 1
+
+    return tweet_ids
 
 def convert_tweet(tweet, username, archive_media_folder, output_media_folder_name,
-                  tweet_icon_path, media_sources, users):
+                  tweet_icon_path, media_sources, users, referenced_tweets):
     """Converts a JSON-format tweet. Returns tuple of timestamp, markdown and HTML."""
+    # TODO actually use `referenced_tweets`
     if 'tweet' in tweet.keys():
         tweet = tweet['tweet']
     timestamp_str = tweet['created_at']
@@ -392,12 +462,53 @@ def parse_tweets(input_filenames, username, users, html_template, archive_media_
    """
     tweets = []
     media_sources = []
+    counts = defaultdict(int)
+    known_tweet_ids = set()
+
+    # TODO Load tweets that we saved in an earlier run between pass 2 and 3
+    
+    # First pass: collect IDs of known tweets
+    for tweets_js_filename in input_filenames:
+        json = read_json_from_js_file(tweets_js_filename)
+        print (f"Processing {len(json)} tweets in {tweets_js_filename}...")
+        for tweet in json:
+            known_tweet_ids.add(collect_tweet_id(tweet))
+
+    # Second pass: collect IDs of references tweets, excluding known tweets from pass 1
+    tweet_ids_to_download = set()
+    for tweets_js_filename in input_filenames:
+        json = read_json_from_js_file(tweets_js_filename)
+        for tweet in json:
+            tweet_ids_to_download.update(collect_tweet_references(tweet, known_tweet_ids, counts))
+
+    # Download referenced tweets
+    referenced_tweets = []
+    if (len(tweet_ids_to_download) > 0):
+        print(f"Found references to {len(tweet_ids_to_download)} tweets which should be downloaded. Breakdown of download reasons:")
+        for reason in ['quote', 'reply', 'retweet', 'media']:
+            print(f" * {counts[reason]} because of {reason}")
+        print(f"There were {counts['known_reply']} references to tweets which are already known so we don't need to download them (not included in the numbers above).")
+        # TODO maybe ask the user if we should start downloading
+        # TODO maybe give an estimate of download size and/or time
+        # TODO maybe let the user choose which of the tweets to download, by selecting a subset of those reasons
+        requests = import_module('requests')
+        try:
+            with requests.Session() as session:
+                bearer_token = 'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA'
+                guest_token = get_twitter_api_guest_token(session, bearer_token)
+                referenced_tweets = get_tweets(session, bearer_token, guest_token, list(tweet_ids_to_download), False)
+                # TODO Save tweets to a file, merging with contents of existing file if present
+                # TODO We could download user data together with the tweets, because we will need it anyway. But we might download the data for each user multiple times then.
+        except Exception as err:
+            print(f'Failed to download tweets: {err}')
+
+    # Third pass: convert tweets, using the downloaded references from pass 2
     for tweets_js_filename in input_filenames:
         json = read_json_from_js_file(tweets_js_filename)
         for tweet in json:
             tweets.append(convert_tweet(tweet, username, archive_media_folder,
                                         output_media_folder_name, tweet_icon_path,
-                                        media_sources, users))
+                                        media_sources, users, referenced_tweets))
     tweets.sort(key=lambda tup: tup[0]) # oldest first
 
     # Group tweets by month (for markdown)


### PR DESCRIPTION
## Why?
We have several issues that can only be solved if we download some additional tweets:
 * #72
 * #73
 * #39
 * #20
 * #22

So I tried to lay the groundwork for those. I hope this common framework prevents overlapping implementations as well as redundant tweet downloads.

## What I did:
 * add method `get_tweets` from some issue conversation between @timhutton and @press-rouch
 * adjusted it a bit to the style of the existing `lookup_users`, which includes the added parameters `include_user` and `include_alt_text`
 * introduced a three-pass approach to tweet processing *(if you want to, I can explain my reasoning for this specific implementation choice, but this text is already long and I don't know if you actually want to have a reasoning for it)*:
   1. collect known tweet IDs, so that we won't download what we already have
   2. collect IDs of references tweets (then download them)
   3. actual tweet conversion

## What's left to do:
 * probably in this PR and branch:
   * save the downloaded tweets in a json file, so that we won't have to re-download them next time
   * several things that are marked with `TODO` in the source code
   * reduce redundant code between `get_tweets` and `lookup_users`
 * probably in another PR / branch /issue:
   * Parse likes and add them to the set of IDs (I did not look into that feature request yet, but I *think* it involves (re-)downloading the tweets)
   * Parse (group) DMs to search for tweets that are quoted there
   * actually use the downloaded tweets (in several separate PRs, since we already have separate issues for that and it's easy to work in parallel on them)

## How it looks and what that means:
I added some print output for debugging and to explain what this does - we can remove some of that before it lands in ´main`:

```
Parsing ./data/account.js...
Parsing ./data/tweets.js...
Processing 42719 tweets in ./data/tweets.js...
Parsing ./data/tweets.js...
Found references to 27911 tweets which should be downloaded. Breakdown of download reasons:
 * 1627 because of quote
 * 9009 because of reply
 * 17373 because of retweet
 * 3705 because of media
There were 7172 references to tweets which are already known so we don't need to download them (not included in the numbers above).
Download 100 tweets of 27911 remaining...
Download 100 tweets of 27811 remaining...
Download 100 tweets of 27711 remaining...
```

In my case, the archive contained 42.719 tweets, and of those 3705 (that's about 9%) have to be downloaded again because they might contain alt-text.

The counts for the different reasons add up to 31.714, but result in only 27.911 downloads (12% less), because each ID is only downloaded once, but might add multiple times to the reason counts (for the same or different reasons).

The numbers seem huge, but since the API returns about 100 tweets per second, those 27911 would be done in less than 5 minutes.

## Where to merge?
**I don't think this PR belongs into your `main` branch**, since it only adds disadvantages for the end user at the moment. But I think it is a good base to work on the issues linked above. In GitHub, I can only create PRs for existing branches. If you agree that these code changes are a good foundation for further features, maybe you could create a new branch and I'll redirect this PR to it?