### PR TITLE
Bugfix: different filenames for parts of long conversations

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -485,6 +485,7 @@ def parse_direct_messages(data_folder, username, users, user_id_URL_template, dm
     lookup_users(list(dm_user_ids), users)
     # Parse the DMs
     num_written_messages = 0
+    long_conversations = []
     for conversation in dms_json:
         markdown = ''
         if 'dmConversation' in conversation and 'conversationId' in conversation['dmConversation']:
@@ -517,6 +518,17 @@ def parse_direct_messages(data_folder, username, users, user_id_URL_template, dm
             other_user_id = user2_id if user1_handle == username else user1_id
             other_user: str = users[other_user_id].handle if other_user_id in users else other_user_id
             conversation_output_filename = dm_output_filename_template.format(other_user)
+
+            # if there are 1000 or more messages, the conversation is split up in the twitter archive.
+            # The first output file should not be overwritten, so the filename has to be adapted.
+            if len(messages) > 999 or other_user in long_conversations:
+                long_conversations.append(other_user)
+            if other_user in long_conversations:
+                part_count = 0
+                for name in long_conversations:
+                    if name == other_user:
+                        part_count += 1
+                conversation_output_filename = dm_output_filename_template.format(other_user+'_part'+str(part_count))
 
             with open(conversation_output_filename, 'w', encoding='utf8') as f:
                 f.write(markdown)


### PR DESCRIPTION
While testing the direct message parsing on a different archive, it stood out to me that there was one user with whom I had talked via DM a lot, and the output looked like it were exactly 1000 messages. That seemed suspicious - and on closer look, the 1000-message-output appeared twice, and there was also a third, shorter one with the same person.

This makes me assume that twitter splits up longer DM conversations into several ones that are up to 1000 messages long. 

The current main version of the dm output would have overwritten any pre-existing file with the same name, so this is my quick first attempt at fixing this bug.
The naming is not super consistent yet, e.g. if the shorter part appears first, it won't get a 'part1' suffix... also, the timeframes of the conversation parts seem to overlap, so there should probably be sorting on all parts together. 
I will improve that later, but I have to go to sleep now and wanted to push at least a working bugfix so other people at least won't have incomplete dm outputs in the meantime.