### PR TITLE
Add curl command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 1. [Download your Twitter archive](https://twitter.com/settings/download_your_data) (Settings > Your account > Download an archive of your data).
 2. Unzip to a folder.
 3. Right-click this link --> [parser.py](https://raw.githubusercontent.com/timhutton/twitter-archive-parser/main/parser.py) <-- and select "Save Link as", and save into the folder where you extracted the archive.
-    - Or with wget: `wget https://raw.githubusercontent.com/timhutton/twitter-archive-parser/main/parser.py` 
+    - Or with `curl`: `curl https://raw.githubusercontent.com/timhutton/twitter-archive-parser/main/parser.py -o parser.py`
+    - Or with `wget`: `wget https://raw.githubusercontent.com/timhutton/twitter-archive-parser/main/parser.py` 
 4. Run parser.py with [Python3](https://realpython.com/installing-python/). e.g. `python parser.py` from a command prompt opened in that folder.
 
 If you are having problems please check the [issues list](https://github.com/timhutton/twitter-archive-parser/issues) to see if it has happened before, and open a new issue otherwise.


### PR DESCRIPTION
`curl` is far (far) more commonly installed than `wget` these days, e.g. it's included on macOS, so figured it would be useful to include a curl download command as well.

If it's too confusing, I would honestly suggest replacing the `wget` command with `curl` entirely.