### PR TITLE
Allow to split the html output by month

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -388,8 +388,8 @@ def download_larger_media(media_sources, log_path):
 
 
 def parse_tweets(input_filenames, username, users, html_template, archive_media_folder,
-                 output_media_folder_name, tweet_icon_path, output_html_filename):
-    """Read tweets from input_filenames, write to *.md and output_html_filename.
+                 output_media_folder_name, tweet_icon_path):
+    """Read tweets from input_filenames, write to *.md and *.html.
        Copy the media used to output_media_folder_name.
        Collect user_id:user_handle mappings for later use, in 'users'.
        Returns the mapping from media filename to best-quality URL.
@@ -412,28 +412,18 @@ def parse_tweets(input_filenames, username, users, html_template, archive_media_
         filename = f'{dt.year}-{dt.month:02}-01-Tweet-Archive-{dt.year}-{dt.month:02}' # change to group by day or year or timestamp
         grouped_tweets[filename].append((md, html))
 
-    user_input = input(f'Group the html output by month? [y/n]')
-    split_html = user_input.lower() in ('y', 'yes')
-
     for filename, content in grouped_tweets.items():
         # Write into *.md files
-        md_string =  '\n\n----\n\n'.join(el[0] for el in content)
+        md_string =  '\n\n----\n\n'.join(md for md, _ in content)
         with open(f'{filename}.md', 'w', encoding='utf-8') as f:
             f.write(md_string)
 
-        if split_html:
-            # Write into *.html files
-            html_string = '<hr>\n'.join(el[1] for el in content)
-            with open(f'{filename}.html', 'w', encoding='utf-8') as f:
-                f.write(html_template.format(html_string))
+        # Write into *.html files
+        html_string = '<hr>\n'.join(html for _, html in content)
+        with open(f'{filename}.html', 'w', encoding='utf-8') as f:
+            f.write(html_template.format(html_string))
 
-    if not split_html:
-        # Write into html file
-        all_html_string = '<hr>\n'.join(html for _, _, html in tweets)
-        with open(output_html_filename, 'w', encoding='utf-8') as f:
-            f.write(html_template.format(all_html_string))
-
-    print(f'Wrote {len(tweets)} tweets to *.md and {"*.html" if split_html else output_html_filename}, with images and video embedded from {output_media_folder_name}')
+    print(f'Wrote {len(tweets)} tweets to *.md and *.html, with images and video embedded from {output_media_folder_name}')
 
     return media_sources
 
@@ -552,7 +542,6 @@ def main():
     input_folder = '.'
     output_media_folder_name = 'media/'
     tweet_icon_path = f'{output_media_folder_name}tweet.ico'
-    output_html_filename = 'TweetArchive.html'
     data_folder = os.path.join(input_folder, 'data')
     account_js_filename = os.path.join(data_folder, 'account.js')
     log_path = os.path.join(output_media_folder_name, 'download_log.txt')
@@ -596,7 +585,7 @@ def main():
         shutil.copy('assets/images/favicon.ico', tweet_icon_path);
 
     media_sources = parse_tweets(input_filenames, username, users, html_template, archive_media_folder,
-                                 output_media_folder_name, tweet_icon_path, output_html_filename)
+                                 output_media_folder_name, tweet_icon_path)
     parse_followings(data_folder, users, user_id_URL_template, output_following_filename)
     parse_followers(data_folder, users, user_id_URL_template, output_followers_filename)
     parse_direct_messages(data_folder, username, users, user_id_URL_template, dm_output_filename_template)


### PR DESCRIPTION
Add a user prompt asking whether to split the html output by month, the same way as the markdown output is being split.  
The markdown and html filenames use the same pattern.

This closes #103 