### PR TITLE
Bugfix: reset markdown for each part

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -528,7 +528,6 @@ def parse_direct_messages(data_folder, username, users, user_id_url_template, dm
     for other_user_id, messages in conversations_messages.items():
         # sort messages by timestamp
         messages.sort(key=lambda tup: tup[0])
-        markdown = ''
 
         other_user_name = \
             users[other_user_id].handle if other_user_id in users else user_id_url_template.format(other_user_id)
@@ -539,6 +538,7 @@ def parse_direct_messages(data_folder, username, users, user_id_url_template, dm
 
         if len(messages) > 1000:
             for chunk_index, chunk in enumerate(chunks(messages, 1000)):
+                markdown = ''
                 markdown += f'## Conversation between {username} and {other_user_name}, part {chunk_index+1}: ##\n'
                 markdown += ''.join(md for _, md in chunk)
                 conversation_output_filename = \
@@ -551,6 +551,7 @@ def parse_direct_messages(data_folder, username, users, user_id_url_template, dm
                 num_written_files += 1
 
         else:
+            markdown = ''
             markdown += f'## Conversation between {username} and {other_user_name}: ##\n'
             markdown += ''.join(md for _, md in messages)
             conversation_output_filename = dm_output_filename_template.format(other_user_short_name)


### PR DESCRIPTION
There was another bug that I only just found while testing, sorry :/

I didn't reset the markdown to empty before starting a new part file, so the content of each file also included the previous one. Should be fixed with this now.