### PR TITLE
Clean up the names and initializations of path variables

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -31,7 +31,6 @@ import subprocess
 import sys
 import time
 # hot-loaded if needed, see import_module():
-#  dataclasses (must be installed for python 3.6, is bundled since 3.7)
 #  imagesize
 #  requests
 
@@ -58,25 +57,6 @@ def import_module(module):
             exit()
         subprocess.run([sys.executable, '-m', 'pip', 'install', module], check=True)
         return importlib.import_module(module)
-
-
-import_module('dataclasses')
-from dataclasses import dataclass
-
-
-@dataclass(frozen=True)
-class PathConfig:
-    dir_archive: str
-    dir_input_data: str
-    dir_input_media: str
-    dir_output_media: str
-    file_output_following: str
-    file_output_followers: str
-    file_template_dm_output: str
-    file_account_js: str
-    file_download_log: str
-    file_tweet_icon: str
-    files_input_tweets: str
 
 
 def get_twitter_api_guest_token(session, bearer_token):
@@ -608,36 +588,23 @@ def parse_direct_messages(username, users, URL_template_user_id, paths):
           f"({num_written_messages} total messages) to {num_written_files} markdown files\n")
 
 
-def init_paths():
-    dir_archive             = '.'
-    dir_input_data          = os.path.join(dir_archive,       'data')
-    dir_input_media         = find_dir_input_media(dir_input_data)
-    dir_output_media        = os.path.join(dir_archive,       'media')
-    file_output_following   = os.path.join(dir_archive,       'following.txt')
-    file_output_followers   = os.path.join(dir_archive,       'followers.txt')
-    file_template_dm_output = os.path.join(dir_archive,       'DMs-Archive-{}.md')
-    file_account_js         = os.path.join(dir_input_data,    'account.js')
-    file_download_log       = os.path.join(dir_output_media,  'download_log.txt')
-    file_tweet_icon         = os.path.join(dir_output_media,  'tweet.ico')
-    files_input_tweets      = find_files_input_tweets(dir_input_data)
-
-    return PathConfig(
-        dir_archive                = dir_archive,
-        dir_input_data             = dir_input_data,
-        dir_input_media            = dir_input_media,
-        dir_output_media           = dir_output_media,
-        file_output_following      = file_output_following,
-        file_output_followers      = file_output_followers,
-        file_template_dm_output    = file_template_dm_output,
-        file_account_js            = file_account_js,
-        file_download_log          = file_download_log,
-        file_tweet_icon            = file_tweet_icon,
-        files_input_tweets         = files_input_tweets,
-    )
-
+class PathConfig:
+    """Helper class containing constants for various directories and files."""
+    def __init__(self, dir_archive, dir_output):
+        self.dir_input_data          = os.path.join(dir_archive,           'data')
+        self.dir_input_media         = find_dir_input_media(self.dir_input_data)
+        self.dir_output_media        = os.path.join(dir_output,            'media')
+        self.file_output_following   = os.path.join(dir_output,            'following.txt')
+        self.file_output_followers   = os.path.join(dir_output,            'followers.txt')
+        self.file_template_dm_output = os.path.join(dir_output,            'DMs-Archive-{}.md')
+        self.file_account_js         = os.path.join(self.dir_input_data,   'account.js')
+        self.file_download_log       = os.path.join(self.dir_output_media, 'download_log.txt')
+        self.file_tweet_icon         = os.path.join(self.dir_output_media, 'tweet.ico')
+        self.files_input_tweets      = find_files_input_tweets(self.dir_input_data)
+ 
 
 def main():
-    paths = init_paths()
+    paths = PathConfig(dir_archive='.', dir_output='.')
 
     # Extract the username from data/account.js
     if not os.path.isfile(paths.file_account_js):

--- a/parser.py
+++ b/parser.py
@@ -162,7 +162,7 @@ def extract_username(paths):
     return account[0]['account']['username']
 
 
-def convert_tweet(tweet, username, paths, media_sources, users):
+def convert_tweet(tweet, username, media_sources, users, paths):
     """Converts a JSON-format tweet. Returns tuple of timestamp, markdown and HTML."""
     if 'tweet' in tweet.keys():
         tweet = tweet['tweet']
@@ -438,7 +438,7 @@ def parse_tweets(username, users, html_template, paths):
     for tweets_js_filename in paths.files_input_tweets:
         json = read_json_from_js_file(tweets_js_filename)
         for tweet in json:
-            tweets.append(convert_tweet(tweet, username, paths, media_sources, users))
+            tweets.append(convert_tweet(tweet, username, media_sources, users, paths))
     tweets.sort(key=lambda tup: tup[0]) # oldest first
 
     # Group tweets by month (for markdown)
@@ -465,7 +465,7 @@ def parse_tweets(username, users, html_template, paths):
     return media_sources
 
 
-def parse_followings(paths, users, URL_template_user_id):
+def parse_followings(users, URL_template_user_id, paths):
     """Parse paths.dir_input_data/following.js, write to paths.file_output_following.
        Query Twitter API for the missing user handles, if the user agrees.
     """
@@ -485,7 +485,7 @@ def parse_followings(paths, users, URL_template_user_id):
     print(f"Wrote {len(following)} accounts to {paths.file_output_following}")
 
 
-def parse_followers(paths, users, URL_template_user_id):
+def parse_followers(users, URL_template_user_id, paths):
     """Parse paths.dir_input_data/followers.js, write to paths.file_output_followers.
        Query Twitter API for the missing user handles, if the user agrees.
     """
@@ -511,7 +511,7 @@ def chunks(lst: list, n: int):
         yield lst[i:i + n]
 
 
-def parse_direct_messages(paths, username, users, URL_template_user_id):
+def parse_direct_messages(username, users, URL_template_user_id, paths):
     """Parse paths.dir_input_data/direct-messages.js, write to one markdown file per conversation.
        Query Twitter API for the missing user handles, if the user agrees.
     """
@@ -613,7 +613,7 @@ def parse_direct_messages(paths, username, users, URL_template_user_id):
 def init_paths():
     dir_archive             = '.'                                                         # used to be `input_folder`
     dir_input_data          = os.path.join(dir_archive,       'data')                     # used to be `data_folder`
-    dir_input_media         = find_dir_input_media(dir_input_data)                   # used to be `archive_media_folder`
+    dir_input_media         = find_dir_input_media(dir_input_data)                        # used to be `archive_media_folder`
     dir_output_media        = os.path.join(dir_archive,       'media')                    # used to be `output_media_folder_name`
     file_output_html        = os.path.join(dir_archive,       'TweetArchive.html')        # used to be `output_html_filename`
     file_output_following   = os.path.join(dir_archive,       'following.txt')            # used to be `output_following_filename`
@@ -622,10 +622,8 @@ def init_paths():
     file_account_js         = os.path.join(dir_input_data,    'account.js')               # used to be `account_js_filename`
     file_download_log       = os.path.join(dir_output_media,  'download_log.txt')         # used to be `log_path`
     file_tweet_icon         = os.path.join(dir_output_media,  'tweet.ico')                # used to be `tweet_icon_path`
-    files_input_tweets      = find_files_input_tweets(dir_input_data)               # used to be `input_filenames`
+    files_input_tweets      = find_files_input_tweets(dir_input_data)                     # used to be `input_filenames`
 
-    # Identify the file and folder names - they change slightly depending on the archive size it seems.
-    
     return PathConfig(
         dir_archive                = dir_archive,
         dir_input_data             = dir_input_data,
@@ -680,9 +678,9 @@ def main():
         shutil.copy('assets/images/favicon.ico', paths.file_tweet_icon);
 
     media_sources = parse_tweets(username, users, html_template, paths)
-    parse_followings(paths, users, URL_template_user_id)
-    parse_followers(paths, users, URL_template_user_id)
-    parse_direct_messages(paths, username, users, URL_template_user_id)
+    parse_followings(users, URL_template_user_id, paths)
+    parse_followers(users, URL_template_user_id, paths)
+    parse_direct_messages(username, users, URL_template_user_id, paths)
 
     # Download larger images, if the user agrees
     print(f"\nThe archive doesn't contain the original-size images. We can attempt to download them from twimg.com.")

--- a/parser.py
+++ b/parser.py
@@ -31,9 +31,9 @@ import subprocess
 import sys
 import time
 # hot-loaded if needed, see import_module():
+#  dataclasses (must be installed for python 3.6, is bundled since 3.7)
 #  imagesize
 #  requests
-#  dataclasses (must be installed for python 3.6, is bundled since 3.7)
 
 
 # Print a compile-time error in Python < 3.6. This line does nothing in Python 3.6+ but is reported to the user
@@ -427,7 +427,7 @@ def download_larger_media(media_sources, paths):
 
 
 def parse_tweets(username, users, html_template, paths):
-    """Read tweets from files_paths_input_tweets, write to *.md and *.html.
+    """Read tweets from paths.files_input_tweets, write to *.md and *.html.
        Copy the media used to paths.dir_output_media.
        Collect user_id:user_handle mappings for later use, in 'users'.
        Returns the mapping from media filename to best-quality URL.
@@ -454,10 +454,10 @@ def parse_tweets(username, users, html_template, paths):
         with open(f'{filename}.md', 'w', encoding='utf-8') as f:
             f.write(md_string)
 
-    # Write into *.html files
-    html_string = '<hr>\n'.join(html for _, html in content)
-    with open(f'{filename}.html', 'w', encoding='utf-8') as f:
-        f.write(html_template.format(html_string))
+        # Write into *.html files
+        html_string = '<hr>\n'.join(html for _, html in content)
+        with open(f'{filename}.html', 'w', encoding='utf-8') as f:
+            f.write(html_template.format(html_string))
 
     print(f'Wrote {len(tweets)} tweets to *.md and *.html, with images and video embedded from {paths.dir_output_media}')
 

--- a/parser.py
+++ b/parser.py
@@ -293,30 +293,30 @@ def convert_tweet(tweet, username, paths, media_sources, users):
     return timestamp, body_markdown, body_html
 
 
-def find_files_paths_input_tweets(dir_path_input_data):
+def find_files_input_tweets(dir_path_input_data):
     """Identify the tweet archive's file and folder names - they change slightly depending on the archive size it seems."""
-    tweet_js_filename_templates = ['tweet.js', 'tweets.js', 'tweets-part*.js']
+    input_tweets_file_templates = ['tweet.js', 'tweets.js', 'tweets-part*.js']
     files_paths_input_tweets = []
-    for tweet_js_filename_template in tweet_js_filename_templates:
-        files_paths_input_tweets += glob.glob(os.path.join(dir_path_input_data, tweet_js_filename_template))
+    for input_tweets_file_template in input_tweets_file_templates:
+        files_paths_input_tweets += glob.glob(os.path.join(dir_path_input_data, input_tweets_file_template))
     if len(files_paths_input_tweets)==0:
-        print(f'Error: no files matching {tweet_js_filename_templates} in {dir_path_input_data}')
+        print(f'Error: no files matching {input_tweets_file_templates} in {dir_path_input_data}')
         exit()
     return files_paths_input_tweets
 
 
-def find_dir_path_input_media(dir_path_input_data):
-    tweet_media_folder_name_templates = ['tweet_media', 'tweets_media']
-    tweet_media_folder_names = []
-    for tweet_media_folder_name_template in tweet_media_folder_name_templates:
-        tweet_media_folder_names += glob.glob(os.path.join(dir_path_input_data, tweet_media_folder_name_template))
-    if len(tweet_media_folder_names) == 0:
-        print(f'Error: no folders matching {tweet_media_folder_name_templates} in {dir_path_input_data}')
+def find_dir_input_media(dir_path_input_data):
+    input_media_dir_templates = ['tweet_media', 'tweets_media']
+    input_media_dirs = []
+    for input_media_dir_template in input_media_dir_templates:
+        input_media_dirs += glob.glob(os.path.join(dir_path_input_data, input_media_dir_template))
+    if len(input_media_dirs) == 0:
+        print(f'Error: no folders matching {input_media_dir_templates} in {dir_path_input_data}')
         exit()
-    if len(tweet_media_folder_names) > 1:
-        print(f'Error: multiple folders matching {tweet_media_folder_name_templates} in {dir_path_input_data}')
+    if len(input_media_dirs) > 1:
+        print(f'Error: multiple folders matching {input_media_dir_templates} in {dir_path_input_data}')
         exit()
-    return tweet_media_folder_names[0]
+    return input_media_dirs[0]
 
 
 def download_file_if_larger(url, filename, index, count, sleep_time):
@@ -613,7 +613,7 @@ def parse_direct_messages(paths, username, users, URL_template_user_id):
 def init_paths():
     dir_archive             = '.'                                                         # used to be `input_folder`
     dir_input_data          = os.path.join(dir_archive,       'data')                     # used to be `data_folder`
-    dir_input_media         = find_dir_path_input_media(dir_input_data)                   # used to be `archive_media_folder`
+    dir_input_media         = find_dir_input_media(dir_input_data)                   # used to be `archive_media_folder`
     dir_output_media        = os.path.join(dir_archive,       'media')                    # used to be `output_media_folder_name`
     file_output_html        = os.path.join(dir_archive,       'TweetArchive.html')        # used to be `output_html_filename`
     file_output_following   = os.path.join(dir_archive,       'following.txt')            # used to be `output_following_filename`
@@ -622,7 +622,7 @@ def init_paths():
     file_account_js         = os.path.join(dir_input_data,    'account.js')               # used to be `account_js_filename`
     file_download_log       = os.path.join(dir_output_media,  'download_log.txt')         # used to be `log_path`
     file_tweet_icon         = os.path.join(dir_output_media,  'tweet.ico')                # used to be `tweet_icon_path`
-    files_input_tweets      = find_files_paths_input_tweets(dir_input_data)               # used to be `input_filenames`
+    files_input_tweets      = find_files_input_tweets(dir_input_data)               # used to be `input_filenames`
 
     # Identify the file and folder names - they change slightly depending on the archive size it seems.
     

--- a/parser.py
+++ b/parser.py
@@ -204,15 +204,16 @@ def convert_tweet(tweet, username, media_sources, users, paths):
                 original_filename = os.path.split(original_expanded_url)[1]
                 archive_media_filename = tweet_id_str + '-' + original_filename
                 archive_media_path = os.path.join(paths.dir_input_media, archive_media_filename)
-                new_url = paths.dir_output_media + archive_media_filename
+                file_output_media = os.path.join(paths.dir_output_media, archive_media_filename)
+                media_url = f'{os.path.split(paths.dir_output_media)[1]}/{archive_media_filename}'
                 markdown += '' if not markdown and body_markdown == original_url else '\n\n'
                 html += '' if not html and body_html == original_url else '<br>'
                 if os.path.isfile(archive_media_path):
                     # Found a matching image, use this one
-                    if not os.path.isfile(new_url):
-                        shutil.copy(archive_media_path, new_url)
-                    markdown += f'![]({new_url})'
-                    html += f'<img src="{new_url}"/>'
+                    if not os.path.isfile(file_output_media):
+                        shutil.copy(archive_media_path, file_output_media)
+                    markdown += f'![]({media_url})'
+                    html += f'<img src="{media_url}"/>'
                     # Save the online location of the best-quality version of this file, for later upgrading if wanted
                     best_quality_url = f'https://pbs.twimg.com/media/{original_filename}:orig'
                     media_sources.append((os.path.join(paths.dir_output_media, archive_media_filename), best_quality_url))
@@ -222,9 +223,10 @@ def convert_tweet(tweet, username, media_sources, users, paths):
                     if len(archive_media_paths) > 0:
                         for archive_media_path in archive_media_paths:
                             archive_media_filename = os.path.split(archive_media_path)[-1]
-                            media_url = f'{paths.dir_output_media}{archive_media_filename}'
-                            if not os.path.isfile(media_url):
-                                shutil.copy(archive_media_path, media_url)
+                            file_output_media = os.path.join(paths.dir_output_media, archive_media_filename)
+                            media_url = f'{os.path.split(paths.dir_output_media)[1]}/{archive_media_filename}'
+                            if not os.path.isfile(file_output_media):
+                                shutil.copy(archive_media_path, file_output_media)
                             markdown += f'<video controls><source src="{media_url}">Your browser does not support the video tag.</video>\n'
                             html += f'<video controls><source src="{media_url}">Your browser does not support the video tag.</video>\n'
                             # Save the online location of the best-quality version of this file, for later upgrading if wanted
@@ -601,7 +603,7 @@ class PathConfig:
         self.file_download_log       = os.path.join(self.dir_output_media, 'download_log.txt')
         self.file_tweet_icon         = os.path.join(self.dir_output_media, 'tweet.ico')
         self.files_input_tweets      = find_files_input_tweets(self.dir_input_data)
- 
+
 
 def main():
     paths = PathConfig(dir_archive='.', dir_output='.')

--- a/parser.py
+++ b/parser.py
@@ -40,11 +40,11 @@ import time
 # as an error (because it is the first line that fails to compile) in older versions.
 f' Error: This script requires Python 3.6 or later. Use `python --version` to check your version.'
 
+
 class UserData:
     def __init__(self, id, handle = None):
         self.id = id
         self.handle = handle
-
 
 
 def import_module(module):
@@ -70,7 +70,6 @@ class PathConfig:
     dir_input_data: str
     dir_input_media: str
     dir_output_media: str
-    file_output_html: str
     file_output_following: str
     file_output_followers: str
     file_template_dm_output: str
@@ -610,25 +609,23 @@ def parse_direct_messages(username, users, URL_template_user_id, paths):
 
 
 def init_paths():
-    dir_archive             = '.'                                                         # used to be `input_folder`
-    dir_input_data          = os.path.join(dir_archive,       'data')                     # used to be `data_folder`
-    dir_input_media         = find_dir_input_media(dir_input_data)                        # used to be `archive_media_folder`
-    dir_output_media        = os.path.join(dir_archive,       'media')                    # used to be `output_media_folder_name`
-    file_output_html        = os.path.join(dir_archive,       'TweetArchive.html')        # used to be `output_html_filename`
-    file_output_following   = os.path.join(dir_archive,       'following.txt')            # used to be `output_following_filename`
-    file_output_followers   = os.path.join(dir_archive,       'followers.txt')            # used to be `output_followers_filename`
-    file_template_dm_output = os.path.join(dir_archive,       'DMs-Archive-{}.md')        # used to be `dm_output_filename_template`
-    file_account_js         = os.path.join(dir_input_data,    'account.js')               # used to be `account_js_filename`
-    file_download_log       = os.path.join(dir_output_media,  'download_log.txt')         # used to be `log_path`
-    file_tweet_icon         = os.path.join(dir_output_media,  'tweet.ico')                # used to be `tweet_icon_path`
-    files_input_tweets      = find_files_input_tweets(dir_input_data)                     # used to be `input_filenames`
+    dir_archive             = '.'
+    dir_input_data          = os.path.join(dir_archive,       'data')
+    dir_input_media         = find_dir_input_media(dir_input_data)
+    dir_output_media        = os.path.join(dir_archive,       'media')
+    file_output_following   = os.path.join(dir_archive,       'following.txt')
+    file_output_followers   = os.path.join(dir_archive,       'followers.txt')
+    file_template_dm_output = os.path.join(dir_archive,       'DMs-Archive-{}.md')
+    file_account_js         = os.path.join(dir_input_data,    'account.js')
+    file_download_log       = os.path.join(dir_output_media,  'download_log.txt')
+    file_tweet_icon         = os.path.join(dir_output_media,  'tweet.ico')
+    files_input_tweets      = find_files_input_tweets(dir_input_data)
 
     return PathConfig(
         dir_archive                = dir_archive,
         dir_input_data             = dir_input_data,
         dir_input_media            = dir_input_media,
         dir_output_media           = dir_output_media,
-        file_output_html           = file_output_html,
         file_output_following      = file_output_following,
         file_output_followers      = file_output_followers,
         file_template_dm_output    = file_template_dm_output,
@@ -649,7 +646,7 @@ def main():
     username = extract_username(paths)
 
     # URL config
-    URL_template_user_id = 'https://twitter.com/i/user/{}' # used to be `user_id_URL_template`
+    URL_template_user_id = 'https://twitter.com/i/user/{}'
 
     html_template = """\
 <!doctype html>

--- a/parser.py
+++ b/parser.py
@@ -603,7 +603,7 @@ def main():
     file_path_tweet_icon         = os.path.join(dir_path_output_media,  'tweet.ico')                # used to be `tweet_icon_path`
     
     # URL config
-    URL_template_user_id = 'https://twitter.com/i/user/{}' # used to be `URL_template_user_id`
+    URL_template_user_id = 'https://twitter.com/i/user/{}' # used to be `user_id_URL_template`
 
     html_template = """\
 <!doctype html>

--- a/parser.py
+++ b/parser.py
@@ -33,13 +33,12 @@ import time
 # hot-loaded if needed, see import_module():
 #  imagesize
 #  requests
+#  dataclasses (must be installed for python 3.6, is bundled since 3.7)
 
 
 # Print a compile-time error in Python < 3.6. This line does nothing in Python 3.6+ but is reported to the user
 # as an error (because it is the first line that fails to compile) in older versions.
 f' Error: This script requires Python 3.6 or later. Use `python --version` to check your version.'
-# To do it more explicitly:
-assert sys.version_info >= (3, 6)
 
 class UserData:
     def __init__(self, id, handle = None):
@@ -61,7 +60,7 @@ def import_module(module):
         return importlib.import_module(module)
 
 
-import_module('dataclasses') # must be installed for python 3.6, is bundled since 3.7
+import_module('dataclasses')
 from dataclasses import dataclass
 
 


### PR DESCRIPTION
I've noticed that there's a dozen of path variables at the start of main which do not follow a common naming pattern, and the way that their initializations reference each other makes it difficult to understand what is where:

```
    input_folder = '.'
    output_media_folder_name = 'media/'
    tweet_icon_path = f'{output_media_folder_name}tweet.ico'
    output_html_filename = 'TweetArchive.html'
    data_folder = os.path.join(input_folder, 'data')
    account_js_filename = os.path.join(data_folder, 'account.js')
    log_path = os.path.join(output_media_folder_name, 'download_log.txt')
    output_following_filename = 'following.txt'
    output_followers_filename = 'followers.txt'
    user_id_URL_template = 'https://twitter.com/i/user/{}'
    dm_output_filename_template = 'DMs-Archive-{}.md'
```

They end in five different postfixes, but they all represent a path (or path template), either pointing to a regular file or a directory:

 * `_folder`
 * `_folder_name`
 * `_path`
 * `_filename`
 * `_filename_template`

When I implement #99, I need to work a lot with those paths, and because the initialization code needs to access the old paths to move things over to the new paths, I'll have to add even more of those variables. It's hard to find matching names for them right now.

So what do you think of a common naming pattern like this? I'll replicate the important part of my change here, since it's kinda buried at the bottom of the diff. This change does not affect how the program works, everything should still be in the same place. (So this does not solve #99, not even partially, it's just preparation for a cleaner implementation of #99.)

```python
    dir_path_archive             = '.'                                                              # used to be `input_folder`
    dir_path_output_media        = os.path.join(dir_path_archive,       'media')                    # used to be `output_media_folder_name`
    dir_path_input_data          = os.path.join(dir_path_archive,       'data')                     # used to be `data_folder`
    file_path_output_html        = os.path.join(dir_path_archive,       'TweetArchive.html')        # used to be `output_html_filename`
    file_path_output_following   = os.path.join(dir_path_archive,       'following.txt')            # used to be `output_following_filename`
    file_path_output_followers   = os.path.join(dir_path_archive,       'followers.txt')            # used to be `output_followers_filename`
    file_path_template_dm_output = os.path.join(dir_path_archive,       'DMs-Archive-{}.md')        # used to be `dm_output_filename_template`
    file_path_account_js         = os.path.join(dir_path_input_data,    'account.js')               # used to be `account_js_filename`
    file_path_download_log       = os.path.join(dir_path_output_media,  'download_log.txt')         # used to be `log_path`
    file_path_tweet_icon         = os.path.join(dir_path_output_media,  'tweet.ico')                # used to be `tweet_icon_path`
```

I'm not always a fan of *identifier prefixes* like `dir_path_` but I think it makes it much easier to see what's the same and what's different between adjacent lines.

The comments like `# used to be log_path` are there to help others resolve merge problems. Later, we won't need the old names for anything and could delete the comments.

Also, I think these path variables are *conceptually* immutable and globally valid, so I'm not very happy with the long argument lists in function calls just to pass them around. I'd really like to make them globally accessible, but I'm not sure what's the best way to do that in python. True global variables? Put them in a dict and make that dict global? Or pass that dict around, instead of several individual vars? Singleton?!

Depending on that, I might also change the variable names to *screaming snake case*, i.e. `FILE_PATH_ACCOUNT_JS` instead of `file_path_account_js`.