### PR TITLE
Put generated output in its own folder(s). Should fix #99.

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -45,6 +45,7 @@ class UserData:
         self.id = id
         self.handle = handle
 
+
 class PathConfig:
     """
     Helper class containing constants for various directories and files.
@@ -184,6 +185,7 @@ def lookup_users(user_ids, users):
                 users[user_id] = UserData(user_id, user["screen_name"])
     except Exception as err:
         print(f'Failed to download user data: {err}')
+
 
 def read_json_from_js_file(filename):
     """Reads the contents of a Twitter-produced .js file into a dictionary."""
@@ -1080,6 +1082,10 @@ def parse_group_direct_messages(username, users, user_id_url_template, paths):
 
 
 def migrate_old_output(paths: PathConfig):
+    """If present, moves media and cache files from the archive root to the new locations in 
+    `paths.dir_output_media` and `paths.dir_output_cache`. Then deletes old output files 
+    (md, html, txt) from the archive root, if the user consents."""
+
     # Create new media folder, so we can potentially use it to move files there
     os.makedirs(paths.dir_output_media, exist_ok=True)
 
@@ -1170,8 +1176,6 @@ def main():
     os.makedirs(paths.dir_output_media, exist_ok=True)
     if not os.path.isfile(paths.file_tweet_icon):
         shutil.copy('assets/images/favicon.ico', paths.file_tweet_icon)
-
-    # TODO move files from older top-level folders, if they have been written by an older version of this script
 
     media_sources = parse_tweets(username, users, html_template, paths)
     parse_followings(users, URL_template_user_id, paths)


### PR DESCRIPTION
Draft not ready for merging.

What I did:
 * Add a group `create_path_for_file_` methods in `PathConfig` and use them. These are now the central point of configuration for how filenames are constructed from several pieces, and it's very close to the point where folder names and paths are configured.
 * Add small helper methods `open_and_mkdirs`, `mkdirs_for_file`
 * Added  and used method `rel_url`, which returns the relative URL to go from one file path (e.g. a md or html file) to another (e.g. an embedded image)
 * Move class `PathConfig` to the top and add some minimal type annotations, so that IDEs can show helpful tooltips (works with VSCode)
 * Add method `migrate_old_output` which looks for leftovers of previous runs in the archive root, and (re)moves them, depending on whether they would be re-users or re-built, and if the user consents.

What's still missing or not matching the discussion in #99:
 * Folder structure is not (yet) as discussed.
 * Tweet archives used to have filenames like `f'{dt.year}-{dt.month:02}-01-Tweet-Archive-{dt.year}-{dt.month:02}'` which contains the date twice, to be compatible with Jekyll. This is currently not followed by `create_path_for_file_output_tweets`.

The new `create_path_for_file_` methods in `PathConfig` make it very easy to change the desired folder structure, because only a single line of code must be changed. Relative paths from `*.html` or `*.md` to the media files will be generated accordingly by `rel_url`.

If we event want to let users choose their folder structure without changing the code, it should now be simple to add that feature. (Like those good ol' music managing tools that let you write path templates like `/MyMusic/%Artist/%Year - %Album %DiscIndex/%TrackIndex %Artist - %TrackName.%Ext`).