### PR TITLE
Extract collecting userids and do handle lookup in bulk

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -102,7 +102,7 @@ def lookup_users(user_ids, users):
     # Account metadata observed at ~2.1KB on average.
     estimated_size = int(2.1 * len(filtered_user_ids))
     print(f'\n{len(filtered_user_ids)} users are unknown.')
-    user_input = input(f'Download user data from Twitter (approx {estimated_size:,}KB)? [y/n]')
+    user_input = input(f'Download user data from Twitter (approx {estimated_size:,} KB)? [y/N]')
     if user_input.lower() not in ('y', 'yes'):
         return
     requests = import_module('requests')
@@ -174,7 +174,8 @@ def convert_tweet(tweet, username, media_sources, users, paths):
                 body_markdown = body_markdown.replace(url['url'], expanded_url)
                 expanded_url_html = f'<a href="{expanded_url}">{expanded_url}</a>'
                 body_html = body_html.replace(url['url'], expanded_url_html)
-    # if the tweet is a reply, construct a header that links the names of the accounts being replied to the tweet being replied to
+    # if the tweet is a reply, construct a header that links the names of the accounts being replied to
+    # to the tweet being replied to
     header_markdown = ''
     header_html = ''
     if 'in_reply_to_status_id' in tweet:
@@ -196,7 +197,8 @@ def convert_tweet(tweet, username, media_sources, users, paths):
         header_markdown += f'Replying to [{name_list}]({replying_to_url})\n\n'
         header_html += f'Replying to <a href="{replying_to_url}">{name_list}</a><br>'
     # replace image URLs with image links to local files
-    if 'entities' in tweet and 'media' in tweet['entities'] and 'extended_entities' in tweet and 'media' in tweet['extended_entities']:
+    if 'entities' in tweet and 'media' in tweet['entities'] and 'extended_entities' in tweet \
+            and 'media' in tweet['extended_entities']:
         original_url = tweet['entities']['media'][0]['url']
         markdown = ''
         html = ''
@@ -229,9 +231,12 @@ def convert_tweet(tweet, username, media_sources, users, paths):
                             media_url = f'{os.path.split(paths.dir_output_media)[1]}/{archive_media_filename}'
                             if not os.path.isfile(file_output_media):
                                 shutil.copy(archive_media_path, file_output_media)
-                            markdown += f'<video controls><source src="{media_url}">Your browser does not support the video tag.</video>\n'
-                            html += f'<video controls><source src="{media_url}">Your browser does not support the video tag.</video>\n'
-                            # Save the online location of the best-quality version of this file, for later upgrading if wanted
+                            markdown += f'<video controls><source src="{media_url}">Your browser ' \
+                                        f'does not support the video tag.</video>\n'
+                            html += f'<video controls><source src="{media_url}">Your browser ' \
+                                    f'does not support the video tag.</video>\n'
+                            # Save the online location of the best-quality version of this file,
+                            # for later upgrading if wanted
                             if 'video_info' in media and 'variants' in media['video_info']:
                                 best_quality_url = ''
                                 best_bitrate = -1 # some valid videos are marked with bitrate=0 in the JSON
@@ -257,8 +262,10 @@ def convert_tweet(tweet, username, media_sources, users, paths):
     body_html = '<p><blockquote>' + '<br>\n'.join(body_html.splitlines()) + '</blockquote>'
     # append the original Twitter URL as a link
     original_tweet_url = f'https://twitter.com/{username}/status/{tweet_id_str}'
-    body_markdown = header_markdown + body_markdown + f'\n\n<img src="{paths.file_tweet_icon}" width="12" /> [{timestamp_str}]({original_tweet_url})'
-    body_html = header_html + body_html + f'<a href="{original_tweet_url}"><img src="{paths.file_tweet_icon}" width="12" />&nbsp;{timestamp_str}</a></p>'
+    body_markdown = header_markdown + body_markdown + f'\n\n<img src="{paths.file_tweet_icon}" width="12" /> ' \
+                                                      f'[{timestamp_str}]({original_tweet_url})'
+    body_html = header_html + body_html + f'<a href="{original_tweet_url}"><img src="{paths.file_tweet_icon}" ' \
+                                          f'width="12" />&nbsp;{timestamp_str}</a></p>'
     # extract user_id:handle connections
     if 'in_reply_to_user_id' in tweet and 'in_reply_to_screen_name' in tweet:
         id = tweet['in_reply_to_user_id']
@@ -276,7 +283,8 @@ def convert_tweet(tweet, username, media_sources, users, paths):
 
 
 def find_files_input_tweets(dir_path_input_data):
-    """Identify the tweet archive's file and folder names - they change slightly depending on the archive size it seems."""
+    """Identify the tweet archive's file and folder names -
+    they change slightly depending on the archive size it seems."""
     input_tweets_file_templates = ['tweet.js', 'tweets.js', 'tweets-part*.js']
     files_paths_input_tweets = []
     for input_tweets_file_template in input_tweets_file_templates:
@@ -319,11 +327,12 @@ def download_file_if_larger(url, filename, index, count, sleep_time):
     try:
         with requests.get(url, stream=True, timeout=2) as res:
             if not res.status_code == 200:
-                # Try to get content of response as `res.text`. For twitter.com, this will be empty in most (all?) cases.
+                # Try to get content of response as `res.text`.
+                # For twitter.com, this will be empty in most (all?) cases.
                 # It is successfully tested with error responses from other domains.
                 raise Exception(f'Download failed with status "{res.status_code} {res.reason}". Response content: "{res.text}"')
             byte_size_after = int(res.headers['content-length'])
-            if (byte_size_after != byte_size_before):
+            if byte_size_after != byte_size_before:
                 # Proceed with the full download
                 tmp_filename = filename+'.tmp'
                 print(f'{pref}Downloading {url}...            ', end='\r')
@@ -335,30 +344,32 @@ def download_file_if_larger(url, filename, index, count, sleep_time):
                 pixels_before, pixels_after = width_before * height_before, width_after * height_after
                 pixels_percentage_increase = 100.0 * (pixels_after - pixels_before) / pixels_before
 
-                if (width_before == -1 and height_before == -1 and width_after == -1 and height_after == -1):
+                if width_before == -1 and height_before == -1 and width_after == -1 and height_after == -1:
                     # could not check size of both versions, probably a video or unsupported image format
                     os.replace(tmp_filename, filename)
                     bytes_percentage_increase = 100.0 * (byte_size_after - byte_size_before) / byte_size_before
                     logging.info(f'{pref}SUCCESS. New version is {bytes_percentage_increase:3.0f}% '
                                  f'larger in bytes (pixel comparison not possible). {post}')
                     return True, byte_size_after
-                elif (width_before == -1 or height_before == -1 or width_after == -1 or height_after == -1):
+                elif width_before == -1 or height_before == -1 or width_after == -1 or height_after == -1:
                     # could not check size of one version, this should not happen (corrupted download?)
                     logging.info(f'{pref}SKIPPED. Pixel size comparison inconclusive: '
                                  f'{width_before}*{height_before}px vs. {width_after}*{height_after}px. {post}')
                     return False, byte_size_after
-                elif (pixels_after >= pixels_before):
+                elif pixels_after >= pixels_before:
                     os.replace(tmp_filename, filename)
                     bytes_percentage_increase = 100.0 * (byte_size_after - byte_size_before) / byte_size_before
-                    if (bytes_percentage_increase >= 0):
+                    if bytes_percentage_increase >= 0:
                         logging.info(f'{pref}SUCCESS. New version is {bytes_percentage_increase:3.0f}% larger in bytes '
-                                    f'and {pixels_percentage_increase:3.0f}% larger in pixels. {post}')
+                                     f'and {pixels_percentage_increase:3.0f}% larger in pixels. {post}')
                     else:
-                        logging.info(f'{pref}SUCCESS. New version is actually {-bytes_percentage_increase:3.0f}% smaller in bytes '
-                                f'but {pixels_percentage_increase:3.0f}% larger in pixels. {post}')
+                        logging.info(f'{pref}SUCCESS. New version is actually {-bytes_percentage_increase:3.0f}% '
+                                     f'smaller in bytes but {pixels_percentage_increase:3.0f}% '
+                                     f'larger in pixels. {post}')
                     return True, byte_size_after
                 else:
-                    logging.info(f'{pref}SKIPPED. Online version has {-pixels_percentage_increase:3.0f}% smaller pixel size. {post}')
+                    logging.info(f'{pref}SKIPPED. Online version has {-pixels_percentage_increase:3.0f}% '
+                                 f'smaller pixel size. {post}')
                     return True, byte_size_after
             else:
                 logging.info(f'{pref}SKIPPED. Online version is same byte size, assuming same content. Not downloaded.')
@@ -397,11 +408,13 @@ def download_larger_media(media_sources, paths):
         media_sources = retries
         remaining_tries -= 1
         sleep_time += 2
-        logging.info(f'\n{success_count} of {number_of_files} tested media files are known to be the best-quality available.\n')
+        logging.info(f'\n{success_count} of {number_of_files} tested media files '
+                     f'are known to be the best-quality available.\n')
         if len(retries) == 0:
             break
         if remaining_tries > 0:
-            print(f'----------------------\n\nRetrying the ones that failed, with a longer sleep. {remaining_tries} tries remaining.\n')
+            print(f'----------------------\n\nRetrying the ones that failed, with a longer sleep. '
+                  f'{remaining_tries} tries remaining.\n')
     end_time = time.time()
 
     logging.info(f'Total downloaded: {total_bytes_downloaded/2**20:.1f}MB = {total_bytes_downloaded/2**30:.2f}GB')
@@ -1031,7 +1044,8 @@ class PathConfig:
         # check if user is in correct folder
         if not os.path.isfile(self.file_account_js):
             print(
-                f'Error: Failed to load {self.file_account_js}. Start this script in the root folder of your Twitter archive.')
+                f'Error: Failed to load {self.file_account_js}. '
+                f'Start this script in the root folder of your Twitter archive.')
             exit()
 
         self.dir_input_media = find_dir_input_media(self.dir_input_data)
@@ -1051,7 +1065,6 @@ def main():
     # Extract the archive owner's username from data/account.js
     username = extract_username(paths)
 
-    # URL config
     URL_template_user_id = 'https://twitter.com/i/user/{}'
 
     html_template = """\
@@ -1087,23 +1100,39 @@ def main():
     print(f'found {len(follower_ids)} user IDs in followers.')
     dms_user_ids = collect_user_ids_from_direct_messages(paths)
     print(f'found {len(dms_user_ids)} user IDs in direct messages.')
+    group_dms_user_ids = collect_user_ids_from_group_direct_messages(paths)
+    print(f'found {len(group_dms_user_ids)} user IDs in group direct messages.')
 
-    # bulk lookup for user handles from followers, followings and direct messages
-    collected_user_ids = list(set(following_ids).union(set(follower_ids)).union(set(dms_user_ids)))
+    # bulk lookup for user handles from followers, followings, direct messages and group direct messages
+    collected_user_ids_without_followers = list(
+        set(following_ids).union(set(dms_user_ids)).union(set(group_dms_user_ids))
+    )
+    collected_user_ids_only_in_followers: set = set(follower_ids).difference(set(collected_user_ids_without_followers))
+    collected_user_ids: list = list(set(collected_user_ids_without_followers).union(collected_user_ids_only_in_followers))
+
+    print(f'\nfound {len(collected_user_ids)} user IDs overall.')
+
+    # give the user a choice if followers should be included in the lookup
+    # (but only in case they make up a large amount):
+    unknown_collected_user_ids: set = set(collected_user_ids).difference(users.keys())
+    if len(unknown_collected_user_ids) > 10000:
+        unknown_follower_user_ids: set = unknown_collected_user_ids.intersection(collected_user_ids_only_in_followers)
+        if len(unknown_follower_user_ids) > 5000:
+            # Account metadata observed at ~2.1KB on average.
+            estimated_follower_lookup_size = int(2.1 * len(unknown_follower_user_ids))
+            user_input = input(f'{len(unknown_follower_user_ids)} of the {len(unknown_collected_user_ids)} '
+                               f'user IDs with unknown handles are from your followers. Online lookup would be '
+                               f'about {estimated_follower_lookup_size:,} KB smaller without them.\n'
+                               f'Do you want to include handles of your followers '
+                               f'in the online lookup of user handles? [Y/n]')
+            if user_input in ['n', 'N', 'no', 'No']:
+                collected_user_ids = collected_user_ids_without_followers
+
     lookup_users(collected_user_ids, users)
 
     parse_followings(users, URL_template_user_id, paths)
     parse_followers(users, URL_template_user_id, paths)
     parse_direct_messages(username, users, URL_template_user_id, paths)
-
-    # find user ids to look up from group dms
-    group_dms_user_ids = collect_user_ids_from_group_direct_messages(paths)
-    # TODO: separate the collecting of user ids out of the other parse* functions in the same way
-    #  and pool the lookups together before all of the other parsing & output generation
-    # look them up
-    lookup_users(group_dms_user_ids, users)
-
-    # parse the content of group dms and write to output files
     parse_group_direct_messages(username, users, URL_template_user_id, paths)
 
     # Download larger images, if the user agrees
@@ -1115,7 +1144,8 @@ def main():
     user_input = input('\nOK to start downloading? [y/n]')
     if user_input.lower() in ('y', 'yes'):
         download_larger_media(media_sources, paths)
-        print('In case you set your account to public before initiating the download, do not forget to protect it again.')
+        print('In case you set your account to public before initiating the download, '
+              'do not forget to protect it again.')
 
 
 if __name__ == "__main__":

--- a/parser.py
+++ b/parser.py
@@ -1151,18 +1151,24 @@ def main():
     # give the user a choice if followers should be included in the lookup
     # (but only in case they make up a large amount):
     unknown_collected_user_ids: set = set(collected_user_ids).difference(users.keys())
-    if len(unknown_collected_user_ids) > 10000:
-        unknown_follower_user_ids: set = unknown_collected_user_ids.intersection(collected_user_ids_only_in_followers)
-        if len(unknown_follower_user_ids) > 5000:
-            # Account metadata observed at ~2.1KB on average.
-            estimated_follower_lookup_size = int(2.1 * len(unknown_follower_user_ids))
-            user_input = input(f'{len(unknown_follower_user_ids)} of the {len(unknown_collected_user_ids)} '
-                               f'user IDs with unknown handles are from your followers. Online lookup would be '
-                               f'about {estimated_follower_lookup_size:,} KB smaller without them.\n'
-                               f'Do you want to include handles of your followers '
-                               f'in the online lookup of user handles? [Y/n]')
-            if user_input.lower() in ['n', 'no']:
-                collected_user_ids = collected_user_ids_without_followers
+    unknown_follower_user_ids: set = unknown_collected_user_ids.intersection(collected_user_ids_only_in_followers)
+    if len(unknown_follower_user_ids) > 5000:
+        # Account metadata observed at ~2.1KB on average.
+        estimated_follower_lookup_size = int(2.1 * len(unknown_follower_user_ids))
+        # we can look up at least 3000 users per minute.
+        estimated_max_follower_lookup_time_in_minutes = len(unknown_follower_user_ids) / 3000
+        print(
+            f'For some user IDs, the @handle is not included in the archive data. '
+            f'Unknown user handles can be looked up online.'
+            f'{len(unknown_follower_user_ids)} of {len(unknown_collected_user_ids)} total '
+            f'user IDs with unknown handles are from your followers. Online lookup would be '
+            f'about {estimated_follower_lookup_size:,} KB smaller and up to '
+            f'{estimated_max_follower_lookup_time_in_minutes:.1f} minutes faster without them.\n'
+        )
+        user_input = input(f'Do you want to include handles of your followers '
+                           f'in the online lookup of user handles anyway? [Y/n]')
+        if user_input.lower() in ['n', 'no']:
+            collected_user_ids = collected_user_ids_without_followers
 
     lookup_users(collected_user_ids, users)
 

--- a/parser.py
+++ b/parser.py
@@ -116,6 +116,7 @@ def lookup_users(user_ids, users):
     except Exception as err:
         print(f'Failed to download user data: {err}')
 
+
 def read_json_from_js_file(filename):
     """Reads the contents of a Twitter-produced .js file into a dictionary."""
     print(f'Parsing {filename}...')
@@ -688,17 +689,17 @@ def main():
 
     following_ids = collect_user_ids_from_followings(paths)
     print(f'found {len(following_ids)} user IDs in followings.')
-    lookup_users(following_ids, users)
-    parse_followings(users, URL_template_user_id, paths)
-
     follower_ids = collect_user_ids_from_followers(paths)
     print(f'found {len(follower_ids)} user IDs in followers.')
-    lookup_users(follower_ids, users)
-    parse_followers(users, URL_template_user_id, paths)
-
     dms_user_ids = collect_user_ids_from_direct_messages(paths)
     print(f'found {len(dms_user_ids)} user IDs in direct messages.')
-    lookup_users(dms_user_ids, users)
+
+    # bulk lookup for user handles from followers, followings and direct messages
+    collected_user_ids = list(set(following_ids).union(set(follower_ids)).union(set(dms_user_ids)))
+    lookup_users(collected_user_ids, users)
+
+    parse_followings(users, URL_template_user_id, paths)
+    parse_followers(users, URL_template_user_id, paths)
     parse_direct_messages(username, users, URL_template_user_id, paths)
 
     # Download larger images, if the user agrees

--- a/parser.py
+++ b/parser.py
@@ -101,7 +101,7 @@ def lookup_users(user_ids, users):
         return
     # Account metadata observed at ~2.1KB on average.
     estimated_size = int(2.1 * len(filtered_user_ids))
-    print(f'{len(filtered_user_ids)} users are unknown.')
+    print(f'\n{len(filtered_user_ids)} users are unknown.')
     user_input = input(f'Download user data from Twitter (approx {estimated_size:,}KB)? [y/n]')
     if user_input.lower() not in ('y', 'yes'):
         return
@@ -113,6 +113,7 @@ def lookup_users(user_ids, users):
             retrieved_users = get_twitter_users(session, bearer_token, guest_token, filtered_user_ids)
             for user_id, user in retrieved_users.items():
                 users[user_id] = UserData(user_id, user["screen_name"])
+        print()  # empty line for better readability of output
     except Exception as err:
         print(f'Failed to download user data: {err}')
 


### PR DESCRIPTION
Implementation of [this TODO](https://github.com/flauschzelle/twitter-archive-parser/blob/04e3a75f96f7117dbf7cec7ef1db99de9643a7f4/parser.py#L983) for the other affected types of data (followings, followers, DMs).

The script now only asks 'Download user data from Twitter? [y/n]' once instead of four times. 

Here is an example snippet of the output from this version: (updated)

```
Parsing ./data/account.js...
Parsing ./data/tweets.js...
Wrote 27264 tweets to *.md and *.html, with images and video embedded from ./media
Parsing ./data/following.js...
found 704 user IDs in followings.
Parsing ./data/follower.js...
found 528 user IDs in followers.
Parsing ./data/direct-messages.js...
found 87 user IDs in direct messages.
Parsing ./data/direct-messages-group.js...
found 140 user IDs in group direct messages.

found 1150 user IDs overall.

605 users are unknown.
Download user data from Twitter (approx 1,270 KB)? [y/N]y

Parsing ./data/following.js...
Wrote 704 accounts to ./following.txt
Parsing ./data/follower.js...
Wrote 528 accounts to ./followers.txt
Parsing ./data/direct-messages.js...

...

Wrote 87 direct message conversations (3860 total messages) to 89 markdown files

...

Wrote 18 direct message group conversations (3118 total messages) to 19 markdown files
```