### PR TITLE
More work on `downloadtweets`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Our script does the following:
 - Replaces t.co URLs with their original versions (the ones that can be found in the archive).
 - Copies used images to an output folder, to allow them to be moved to a new home.
 - Will query Twitter for the missing user handles (checks with you first).
-- Converts DMs (including group DMs) to markdown, including the handles that we retrieved.
+- Converts DMs (including group DMs) to markdown with embedded media and links, including the handles that we retrieved.
 - Outputs lists of followers and following.
 - Downloads the original size images (checks with you first).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 1. [Download your Twitter archive](https://twitter.com/settings/download_your_data) (Settings > Your account > Download an archive of your data).
 2. Unzip to a folder.
 3. Right-click this link --> [parser.py](https://raw.githubusercontent.com/timhutton/twitter-archive-parser/main/parser.py) <-- and select "Save Link as", and save into the folder where you extracted the archive. (Or use wget or curl on that link. Or clone the git repo.)
-4. Run parser.py with [Python 3](https://realpython.com/installing-python/). e.g. `python parser.py` from a command prompt opened in that folder.
+4. Open a command prompt and change directory into the unzipped folder where you just saved parser.py.  
+   (**Here's how to do that on Windows:** Hold shift while right-clicking in the folder. Click on `Open PowerShell`.)
+5. Run parser.py with [Python 3](https://realpython.com/installing-python/). e.g. `python parser.py`.  
+  (**On Windows:** When the command window opens, paste or enter `python parser.py` at the command prompt.)
+
+
 
 If you are having problems please check the [issues list](https://github.com/timhutton/twitter-archive-parser/issues?q=is%3Aissue) to see if it has happened before, and open a new issue otherwise.
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Our script does the following:
 Some of the functionality requires the `requests` and `imagesize` modules. `parser.py` will offer to install these for you using pip. To avoid that you can install them before running the script.
 
 ## Articles about handling your Twitter archive:
+- https://techcrunch.com/2022/11/21/quit-twitter-better-with-these-free-tools-that-make-archiving-a-breeze/
 - https://www.bitsgalore.org/2022/11/20/how-to-preserve-your-personal-twitter-archive
 - https://matthiasott.com/notes/converting-your-twitter-archive-to-markdown
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Our script does the following:
 - Replaces t.co URLs with their original versions (the ones that can be found in the archive).
 - Copies used images to an output folder, to allow them to be moved to a new home.
 - Will query Twitter for the missing user handles (checks with you first).
-- Converts DMs to markdown, including the handles that we retrieved. Basic functionality for now (no embedded images), pending improvements.
+- Converts DMs (including group DMs) to markdown, including the handles that we retrieved.
 - Outputs lists of followers and following.
 - Downloads the original size images (checks with you first).
 

--- a/parser.py
+++ b/parser.py
@@ -187,7 +187,7 @@ def collect_tweet_id(tweet):
         tweet = tweet['tweet']
     return tweet['id_str']
 
-# returns an it if you give it either an int or a str that can be parsed as 
+# returns an int if you give it either an int or a str that can be parsed as 
 # an int. Otherwise, returns None.
 def parse_as_number(str_or_number):
     if isinstance(str_or_number, str):

--- a/parser.py
+++ b/parser.py
@@ -456,7 +456,7 @@ def collect_tweet_references(tweet, known_tweets, counts):
     # Collect previous tweets in conversation
     # Only do this for tweets from our original archive
     if 'from_archive' in tweet and has_path(tweet, ['in_reply_to_status_id_str']):
-        prev_tweet_id = parse_as_number(tweet['in_reply_to_status_id_str'])
+        prev_tweet_id = tweet['in_reply_to_status_id_str']
         if (prev_tweet_id in known_tweets):
             counts['known_reply'] += 1
         else:
@@ -824,7 +824,7 @@ def parse_tweets(username, users, html_template, paths: PathConfig) -> dict:
     # 3. use the data that is already present in a tweet to distinguish own tweets from others
 
     # Load tweets that we saved in an earlier run between pass 2 and 3
-    tweet_dict_filename = 'known_tweets.json'
+    tweet_dict_filename = os.path.join(paths.dir_output_cache, 'known_tweets.json')
     if os.path.exists(tweet_dict_filename):
         with open(tweet_dict_filename, 'r', encoding='utf8') as f:
             known_tweets = json.load(f)
@@ -845,7 +845,7 @@ def parse_tweets(username, users, html_template, paths: PathConfig) -> dict:
 
     # (Maybe) download referenced tweets
     referenced_tweets = []
-    if (len(tweet_ids_to_download) > 0):
+    while (len(tweet_ids_to_download) > 0):
         print(f"Found references to {len(tweet_ids_to_download)} tweets which should be downloaded. Breakdown of download reasons:")
         for reason in ['quote', 'reply', 'retweet', 'media']:
             print(f" * {counts[reason]} because of {reason}")
@@ -862,8 +862,8 @@ def parse_tweets(username, users, html_template, paths: PathConfig) -> dict:
                     bearer_token = 'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA'
                     guest_token = get_twitter_api_guest_token(session, bearer_token)
                     # TODO We could download user data together with the tweets, because we will need it anyway. But we might download the data for each user multiple times then.
-                    downloaded_tweets, remaining_tweet_ids = get_tweets(session, bearer_token, guest_token, list(tweet_ids_to_download), False)
-                    # TODO maybe react if remaining_tweet_ids contains tweets
+                    downloaded_tweets, tweet_ids_to_download = get_tweets(session, bearer_token, guest_token, list(tweet_ids_to_download), False)
+
                     for downloaded_tweet in downloaded_tweets.values():
                         downloaded_tweet = unwrap_tweet(downloaded_tweet)
                         downloaded_tweet['from_api'] = True

--- a/parser.py
+++ b/parser.py
@@ -599,26 +599,32 @@ def parse_direct_messages(username, users, URL_template_user_id, paths):
 
 class PathConfig:
     """Helper class containing constants for various directories and files."""
+
     def __init__(self, dir_archive, dir_output):
-        self.dir_input_data          = os.path.join(dir_archive,           'data')
-        self.dir_input_media         = find_dir_input_media(self.dir_input_data)
-        self.dir_output_media        = os.path.join(dir_output,            'media')
-        self.file_output_following   = os.path.join(dir_output,            'following.txt')
-        self.file_output_followers   = os.path.join(dir_output,            'followers.txt')
-        self.file_template_dm_output = os.path.join(dir_output,            'DMs-Archive-{}.md')
-        self.file_account_js         = os.path.join(self.dir_input_data,   'account.js')
-        self.file_download_log       = os.path.join(self.dir_output_media, 'download_log.txt')
-        self.file_tweet_icon         = os.path.join(self.dir_output_media, 'tweet.ico')
-        self.files_input_tweets      = find_files_input_tweets(self.dir_input_data)
+        self.dir_input_data = os.path.join(dir_archive, 'data')
+        self.file_account_js = os.path.join(self.dir_input_data, 'account.js')
+
+        # check if user is in correct folder
+        if not os.path.isfile(self.file_account_js):
+            print(
+                f'Error: Failed to load {self.file_account_js}. Start this script in the root folder of your Twitter archive.')
+            exit()
+
+        self.dir_input_media = find_dir_input_media(self.dir_input_data)
+        self.dir_output_media = os.path.join(dir_output, 'media')
+        self.file_output_following = os.path.join(dir_output, 'following.txt')
+        self.file_output_followers = os.path.join(dir_output, 'followers.txt')
+        self.file_template_dm_output = os.path.join(dir_output, 'DMs-Archive-{}.md')
+
+        self.file_download_log = os.path.join(self.dir_output_media, 'download_log.txt')
+        self.file_tweet_icon = os.path.join(self.dir_output_media, 'tweet.ico')
+        self.files_input_tweets = find_files_input_tweets(self.dir_input_data)
 
 
 def main():
     paths = PathConfig(dir_archive='.', dir_output='.')
 
-    # Extract the username from data/account.js
-    if not os.path.isfile(paths.file_account_js):
-        print(f'Error: Failed to load {paths.file_account_js}. Start this script in the root folder of your Twitter archive.')
-        exit()
+    # Extract the archive owner's username from data/account.js
     username = extract_username(paths)
 
     # URL config

--- a/parser.py
+++ b/parser.py
@@ -1232,7 +1232,6 @@ def migrate_old_output(paths: PathConfig):
             print(f"Moving {len(files_to_move)} files from 'media' to '{paths.dir_output_media}'")
             for file_path_to_move in files_to_move:
                 file_name_to_move = os.path.split(file_path_to_move)[1]
-                print(file_name_to_move)
                 os.rename(file_path_to_move, os.path.join(paths.dir_output_media, file_name_to_move))
         os.rmdir(os.path.join(paths.dir_archive, "media"))
 

--- a/parser.py
+++ b/parser.py
@@ -102,7 +102,7 @@ def lookup_users(user_ids, users):
     # Account metadata observed at ~2.1KB on average.
     estimated_size = int(2.1 * len(filtered_user_ids))
     print(f'\n{len(filtered_user_ids)} users are unknown.')
-    user_input = input(f'Download user data from Twitter (approx {estimated_size:,}KB)? [y/n]')
+    user_input = input(f'Download user data from Twitter (approx {estimated_size:,} KB)? [y/N]')
     if user_input.lower() not in ('y', 'yes'):
         return
     requests = import_module('requests')
@@ -174,7 +174,8 @@ def convert_tweet(tweet, username, media_sources, users, paths):
                 body_markdown = body_markdown.replace(url['url'], expanded_url)
                 expanded_url_html = f'<a href="{expanded_url}">{expanded_url}</a>'
                 body_html = body_html.replace(url['url'], expanded_url_html)
-    # if the tweet is a reply, construct a header that links the names of the accounts being replied to the tweet being replied to
+    # if the tweet is a reply, construct a header that links the names of the accounts being replied to
+    # to the tweet being replied to
     header_markdown = ''
     header_html = ''
     if 'in_reply_to_status_id' in tweet:
@@ -196,7 +197,8 @@ def convert_tweet(tweet, username, media_sources, users, paths):
         header_markdown += f'Replying to [{name_list}]({replying_to_url})\n\n'
         header_html += f'Replying to <a href="{replying_to_url}">{name_list}</a><br>'
     # replace image URLs with image links to local files
-    if 'entities' in tweet and 'media' in tweet['entities'] and 'extended_entities' in tweet and 'media' in tweet['extended_entities']:
+    if 'entities' in tweet and 'media' in tweet['entities'] and 'extended_entities' in tweet \
+            and 'media' in tweet['extended_entities']:
         original_url = tweet['entities']['media'][0]['url']
         markdown = ''
         html = ''
@@ -229,9 +231,12 @@ def convert_tweet(tweet, username, media_sources, users, paths):
                             media_url = f'{os.path.split(paths.dir_output_media)[1]}/{archive_media_filename}'
                             if not os.path.isfile(file_output_media):
                                 shutil.copy(archive_media_path, file_output_media)
-                            markdown += f'<video controls><source src="{media_url}">Your browser does not support the video tag.</video>\n'
-                            html += f'<video controls><source src="{media_url}">Your browser does not support the video tag.</video>\n'
-                            # Save the online location of the best-quality version of this file, for later upgrading if wanted
+                            markdown += f'<video controls><source src="{media_url}">Your browser ' \
+                                        f'does not support the video tag.</video>\n'
+                            html += f'<video controls><source src="{media_url}">Your browser ' \
+                                    f'does not support the video tag.</video>\n'
+                            # Save the online location of the best-quality version of this file,
+                            # for later upgrading if wanted
                             if 'video_info' in media and 'variants' in media['video_info']:
                                 best_quality_url = ''
                                 best_bitrate = -1 # some valid videos are marked with bitrate=0 in the JSON
@@ -257,8 +262,10 @@ def convert_tweet(tweet, username, media_sources, users, paths):
     body_html = '<p><blockquote>' + '<br>\n'.join(body_html.splitlines()) + '</blockquote>'
     # append the original Twitter URL as a link
     original_tweet_url = f'https://twitter.com/{username}/status/{tweet_id_str}'
-    body_markdown = header_markdown + body_markdown + f'\n\n<img src="{paths.file_tweet_icon}" width="12" /> [{timestamp_str}]({original_tweet_url})'
-    body_html = header_html + body_html + f'<a href="{original_tweet_url}"><img src="{paths.file_tweet_icon}" width="12" />&nbsp;{timestamp_str}</a></p>'
+    body_markdown = header_markdown + body_markdown + f'\n\n<img src="{paths.file_tweet_icon}" width="12" /> ' \
+                                                      f'[{timestamp_str}]({original_tweet_url})'
+    body_html = header_html + body_html + f'<a href="{original_tweet_url}"><img src="{paths.file_tweet_icon}" ' \
+                                          f'width="12" />&nbsp;{timestamp_str}</a></p>'
     # extract user_id:handle connections
     if 'in_reply_to_user_id' in tweet and 'in_reply_to_screen_name' in tweet:
         id = tweet['in_reply_to_user_id']
@@ -276,7 +283,8 @@ def convert_tweet(tweet, username, media_sources, users, paths):
 
 
 def find_files_input_tweets(dir_path_input_data):
-    """Identify the tweet archive's file and folder names - they change slightly depending on the archive size it seems."""
+    """Identify the tweet archive's file and folder names -
+    they change slightly depending on the archive size it seems."""
     input_tweets_file_templates = ['tweet.js', 'tweets.js', 'tweets-part*.js']
     files_paths_input_tweets = []
     for input_tweets_file_template in input_tweets_file_templates:
@@ -319,11 +327,12 @@ def download_file_if_larger(url, filename, index, count, sleep_time):
     try:
         with requests.get(url, stream=True, timeout=2) as res:
             if not res.status_code == 200:
-                # Try to get content of response as `res.text`. For twitter.com, this will be empty in most (all?) cases.
+                # Try to get content of response as `res.text`.
+                # For twitter.com, this will be empty in most (all?) cases.
                 # It is successfully tested with error responses from other domains.
                 raise Exception(f'Download failed with status "{res.status_code} {res.reason}". Response content: "{res.text}"')
             byte_size_after = int(res.headers['content-length'])
-            if (byte_size_after != byte_size_before):
+            if byte_size_after != byte_size_before:
                 # Proceed with the full download
                 tmp_filename = filename+'.tmp'
                 print(f'{pref}Downloading {url}...            ', end='\r')
@@ -335,30 +344,32 @@ def download_file_if_larger(url, filename, index, count, sleep_time):
                 pixels_before, pixels_after = width_before * height_before, width_after * height_after
                 pixels_percentage_increase = 100.0 * (pixels_after - pixels_before) / pixels_before
 
-                if (width_before == -1 and height_before == -1 and width_after == -1 and height_after == -1):
+                if width_before == -1 and height_before == -1 and width_after == -1 and height_after == -1:
                     # could not check size of both versions, probably a video or unsupported image format
                     os.replace(tmp_filename, filename)
                     bytes_percentage_increase = 100.0 * (byte_size_after - byte_size_before) / byte_size_before
                     logging.info(f'{pref}SUCCESS. New version is {bytes_percentage_increase:3.0f}% '
                                  f'larger in bytes (pixel comparison not possible). {post}')
                     return True, byte_size_after
-                elif (width_before == -1 or height_before == -1 or width_after == -1 or height_after == -1):
+                elif width_before == -1 or height_before == -1 or width_after == -1 or height_after == -1:
                     # could not check size of one version, this should not happen (corrupted download?)
                     logging.info(f'{pref}SKIPPED. Pixel size comparison inconclusive: '
                                  f'{width_before}*{height_before}px vs. {width_after}*{height_after}px. {post}')
                     return False, byte_size_after
-                elif (pixels_after >= pixels_before):
+                elif pixels_after >= pixels_before:
                     os.replace(tmp_filename, filename)
                     bytes_percentage_increase = 100.0 * (byte_size_after - byte_size_before) / byte_size_before
-                    if (bytes_percentage_increase >= 0):
+                    if bytes_percentage_increase >= 0:
                         logging.info(f'{pref}SUCCESS. New version is {bytes_percentage_increase:3.0f}% larger in bytes '
-                                    f'and {pixels_percentage_increase:3.0f}% larger in pixels. {post}')
+                                     f'and {pixels_percentage_increase:3.0f}% larger in pixels. {post}')
                     else:
-                        logging.info(f'{pref}SUCCESS. New version is actually {-bytes_percentage_increase:3.0f}% smaller in bytes '
-                                f'but {pixels_percentage_increase:3.0f}% larger in pixels. {post}')
+                        logging.info(f'{pref}SUCCESS. New version is actually {-bytes_percentage_increase:3.0f}% '
+                                     f'smaller in bytes but {pixels_percentage_increase:3.0f}% '
+                                     f'larger in pixels. {post}')
                     return True, byte_size_after
                 else:
-                    logging.info(f'{pref}SKIPPED. Online version has {-pixels_percentage_increase:3.0f}% smaller pixel size. {post}')
+                    logging.info(f'{pref}SKIPPED. Online version has {-pixels_percentage_increase:3.0f}% '
+                                 f'smaller pixel size. {post}')
                     return True, byte_size_after
             else:
                 logging.info(f'{pref}SKIPPED. Online version is same byte size, assuming same content. Not downloaded.')
@@ -397,11 +408,13 @@ def download_larger_media(media_sources, paths):
         media_sources = retries
         remaining_tries -= 1
         sleep_time += 2
-        logging.info(f'\n{success_count} of {number_of_files} tested media files are known to be the best-quality available.\n')
+        logging.info(f'\n{success_count} of {number_of_files} tested media files '
+                     f'are known to be the best-quality available.\n')
         if len(retries) == 0:
             break
         if remaining_tries > 0:
-            print(f'----------------------\n\nRetrying the ones that failed, with a longer sleep. {remaining_tries} tries remaining.\n')
+            print(f'----------------------\n\nRetrying the ones that failed, with a longer sleep. '
+                  f'{remaining_tries} tries remaining.\n')
     end_time = time.time()
 
     logging.info(f'Total downloaded: {total_bytes_downloaded/2**20:.1f}MB = {total_bytes_downloaded/2**30:.2f}GB')
@@ -1031,7 +1044,8 @@ class PathConfig:
         # check if user is in correct folder
         if not os.path.isfile(self.file_account_js):
             print(
-                f'Error: Failed to load {self.file_account_js}. Start this script in the root folder of your Twitter archive.')
+                f'Error: Failed to load {self.file_account_js}. '
+                f'Start this script in the root folder of your Twitter archive.')
             exit()
 
         self.dir_input_media = find_dir_input_media(self.dir_input_data)
@@ -1051,7 +1065,6 @@ def main():
     # Extract the archive owner's username from data/account.js
     username = extract_username(paths)
 
-    # URL config
     URL_template_user_id = 'https://twitter.com/i/user/{}'
 
     html_template = """\
@@ -1087,23 +1100,39 @@ def main():
     print(f'found {len(follower_ids)} user IDs in followers.')
     dms_user_ids = collect_user_ids_from_direct_messages(paths)
     print(f'found {len(dms_user_ids)} user IDs in direct messages.')
+    group_dms_user_ids = collect_user_ids_from_group_direct_messages(paths)
+    print(f'found {len(group_dms_user_ids)} user IDs in group direct messages.')
 
-    # bulk lookup for user handles from followers, followings and direct messages
-    collected_user_ids = list(set(following_ids).union(set(follower_ids)).union(set(dms_user_ids)))
+    # bulk lookup for user handles from followers, followings, direct messages and group direct messages
+    collected_user_ids_without_followers = list(
+        set(following_ids).union(set(dms_user_ids)).union(set(group_dms_user_ids))
+    )
+    collected_user_ids_only_in_followers: set = set(follower_ids).difference(set(collected_user_ids_without_followers))
+    collected_user_ids: list = list(set(collected_user_ids_without_followers).union(collected_user_ids_only_in_followers))
+
+    print(f'\nfound {len(collected_user_ids)} user IDs overall.')
+
+    # give the user a choice if followers should be included in the lookup
+    # (but only in case they make up a large amount):
+    unknown_collected_user_ids: set = set(collected_user_ids).difference(users.keys())
+    if len(unknown_collected_user_ids) > 10000:
+        unknown_follower_user_ids: set = unknown_collected_user_ids.intersection(collected_user_ids_only_in_followers)
+        if len(unknown_follower_user_ids) > 5000:
+            # Account metadata observed at ~2.1KB on average.
+            estimated_follower_lookup_size = int(2.1 * len(unknown_follower_user_ids))
+            user_input = input(f'{len(unknown_follower_user_ids)} of the {len(unknown_collected_user_ids)} '
+                               f'user IDs with unknown handles are from your followers. Online lookup would be '
+                               f'about {estimated_follower_lookup_size:,} KB smaller without them.\n'
+                               f'Do you want to include handles of your followers '
+                               f'in the online lookup of user handles? [Y/n]')
+            if user_input in ['n', 'N', 'no', 'No']:
+                collected_user_ids = collected_user_ids_without_followers
+
     lookup_users(collected_user_ids, users)
 
     parse_followings(users, URL_template_user_id, paths)
     parse_followers(users, URL_template_user_id, paths)
     parse_direct_messages(username, users, URL_template_user_id, paths)
-
-    # find user ids to look up from group dms
-    group_dms_user_ids = collect_user_ids_from_group_direct_messages(paths)
-    # TODO: separate the collecting of user ids out of the other parse* functions in the same way
-    #  and pool the lookups together before all of the other parsing & output generation
-    # look them up
-    lookup_users(group_dms_user_ids, users)
-
-    # parse the content of group dms and write to output files
     parse_group_direct_messages(username, users, URL_template_user_id, paths)
 
     # Download larger images, if the user agrees
@@ -1115,7 +1144,8 @@ def main():
     user_input = input('\nOK to start downloading? [y/n]')
     if user_input.lower() in ('y', 'yes'):
         download_larger_media(media_sources, paths)
-        print('In case you set your account to public before initiating the download, do not forget to protect it again.')
+        print('In case you set your account to public before initiating the download, '
+              'do not forget to protect it again.')
 
 
 if __name__ == "__main__":

--- a/parser.py
+++ b/parser.py
@@ -442,6 +442,10 @@ def collect_tweet_references(tweet, known_tweets, counts):
     tweet = unwrap_tweet(tweet)
     tweet_ids = set()
 
+    # Don't search for tweet references if this tweet was not part of the original archive
+    if 'from_archive' not in tweet:
+        return tweet_ids
+
     # Collect quoted tweets
     if has_path(tweet, ['entities', 'urls']):
         for url in tweet['entities']['urls']:

--- a/parser.py
+++ b/parser.py
@@ -519,6 +519,7 @@ def parse_direct_messages(data_folder, output_media_folder_name, username, users
                                 original_expanded_url = message_create['urls'][0]['expanded']
                                 message_id = message_create['id']
                                 media_hash_and_type = message_create['mediaUrls'][0].split('/')[-1]
+                                media_id = message_create['mediaUrls'][0].split('/')[-2]
                                 archive_media_filename = f'{message_id}-{media_hash_and_type}'
                                 new_url = output_media_folder_name + archive_media_filename
                                 archive_media_path = \
@@ -530,9 +531,24 @@ def parse_direct_messages(data_folder, output_media_folder_name, username, users
                                     image_markdown = f'\n![]({new_url})\n'
                                     body = body.replace(original_expanded_url, image_markdown)
 
-                                    # TODO: Save the online location of the best-quality version of this file,
-                                    #  for later upgrading if wanted (see convert_tweet method, but probably
-                                    #  with a different url scheme)
+                                    # Save the online location of the best-quality version of this file,
+                                    # for later upgrading if wanted
+                                    best_quality_url = \
+                                        f'https://ton.twitter.com/i//ton/data/dm/' \
+                                        f'{message_id}/{media_id}/{media_hash_and_type}'
+                                    # there is no ':orig' here, the url without any suffix has the original size
+
+                                    # TODO: a cookie (and a 'Referer: https://twitter.com' header)
+                                    #  is needed to retrieve it, so the url might be useless anyway...
+
+                                    # WARNING: Do not uncomment the statement below until the cookie problem is solved!
+                                    # media_sources.append(
+                                    #     (
+                                    #         os.path.join(output_media_folder_name, archive_media_filename),
+                                    #         best_quality_url
+                                    #     )
+                                    # )
+
                                 else:
                                     archive_media_paths = glob.glob(
                                         os.path.join(data_folder, 'direct_messages_media', message_id + '*'))
@@ -545,7 +561,10 @@ def parse_direct_messages(data_folder, output_media_folder_name, username, users
                                             video_markdown = f'\n<video controls><source src="{media_url}">' \
                                                              f'Your browser does not support the video tag.</video>\n'
                                             body = body.replace(original_expanded_url, video_markdown)
-                                    # TODO: save the online location of the best-quality version (see above)
+
+                                    # TODO: maybe  also save the online location of the best-quality version for videos?
+                                    #  (see above)
+
                                     else:
                                         print(f'Warning: missing local file: {archive_media_path}. '
                                               f'Using original link instead: {original_expanded_url})')

--- a/parser.py
+++ b/parser.py
@@ -45,6 +45,7 @@ class UserData:
         self.id = id
         self.handle = handle
 
+
 class PathConfig:
     """
     Helper class containing constants for various directories and files.
@@ -184,6 +185,7 @@ def lookup_users(user_ids, users):
                 users[user_id] = UserData(user_id, user["screen_name"])
     except Exception as err:
         print(f'Failed to download user data: {err}')
+
 
 def read_json_from_js_file(filename):
     """Reads the contents of a Twitter-produced .js file into a dictionary."""
@@ -1080,6 +1082,10 @@ def parse_group_direct_messages(username, users, user_id_url_template, paths):
 
 
 def migrate_old_output(paths: PathConfig):
+    """If present, moves media and cache files from the archive root to the new locations in 
+    `paths.dir_output_media` and `paths.dir_output_cache`. Then deletes old output files 
+    (md, html, txt) from the archive root, if the user consents."""
+
     # Create new media folder, so we can potentially use it to move files there
     os.makedirs(paths.dir_output_media, exist_ok=True)
 
@@ -1170,8 +1176,6 @@ def main():
     os.makedirs(paths.dir_output_media, exist_ok=True)
     if not os.path.isfile(paths.file_tweet_icon):
         shutil.copy('assets/images/favicon.ico', paths.file_tweet_icon)
-
-    # TODO move files from older top-level folders, if they have been written by an older version of this script
 
     media_sources = parse_tweets(username, users, html_template, paths)
     parse_followings(users, URL_template_user_id, paths)

--- a/parser.py
+++ b/parser.py
@@ -961,6 +961,9 @@ def parse_group_direct_messages(username, users, user_id_url_template, paths):
             group_conversations_metadata[conversation_id]['participant_names'] = participant_names
             group_conversations_metadata[conversation_id]['conversation_names'] = [(0, conversation_id)]
             group_conversations_metadata[conversation_id]['participant_message_count'] = defaultdict(int)
+            for participant_id in participants:
+                # init every participant's message count with 0, so that users with no activity are not ignored
+                group_conversations_metadata[conversation_id]['participant_message_count'][participant_id] = 0
             messages = []
             if 'messages' in dm_conversation:
                 for message in dm_conversation['messages']:
@@ -1156,6 +1159,8 @@ def parse_group_direct_messages(username, users, user_id_url_template, paths):
                     participant_handle = users[participant_id].handle
                     if participant_handle != username:
                         handles.append((participant_handle, message_count))
+            # sort alphabetically by handle first, for a more deterministic order
+            handles.sort(key=lambda tup: tup[0])
             # sort so that the most active users are at the start of the list
             handles.sort(key=lambda tup: tup[1], reverse=True)
             if len(handles) == 1:

--- a/parser.py
+++ b/parser.py
@@ -1151,18 +1151,24 @@ def main():
     # give the user a choice if followers should be included in the lookup
     # (but only in case they make up a large amount):
     unknown_collected_user_ids: set = set(collected_user_ids).difference(users.keys())
-    if len(unknown_collected_user_ids) > 10000:
-        unknown_follower_user_ids: set = unknown_collected_user_ids.intersection(collected_user_ids_only_in_followers)
-        if len(unknown_follower_user_ids) > 5000:
-            # Account metadata observed at ~2.1KB on average.
-            estimated_follower_lookup_size = int(2.1 * len(unknown_follower_user_ids))
-            user_input = input(f'{len(unknown_follower_user_ids)} of the {len(unknown_collected_user_ids)} '
-                               f'user IDs with unknown handles are from your followers. Online lookup would be '
-                               f'about {estimated_follower_lookup_size:,} KB smaller without them.\n'
-                               f'Do you want to include handles of your followers '
-                               f'in the online lookup of user handles? [Y/n]')
-            if user_input.lower() in ['n', 'no']:
-                collected_user_ids = collected_user_ids_without_followers
+    unknown_follower_user_ids: set = unknown_collected_user_ids.intersection(collected_user_ids_only_in_followers)
+    if len(unknown_follower_user_ids) > 5000:
+        # Account metadata observed at ~2.1KB on average.
+        estimated_follower_lookup_size = int(2.1 * len(unknown_follower_user_ids))
+        # we can look up at least 3000 users per minute.
+        estimated_max_follower_lookup_time_in_minutes = len(unknown_follower_user_ids) / 3000
+        print(
+            f'For some user IDs, the @handle is not included in the archive data. '
+            f'Unknown user handles can be looked up online.'
+            f'{len(unknown_follower_user_ids)} of {len(unknown_collected_user_ids)} total '
+            f'user IDs with unknown handles are from your followers. Online lookup would be '
+            f'about {estimated_follower_lookup_size:,} KB smaller and up to '
+            f'{estimated_max_follower_lookup_time_in_minutes:.1f} minutes faster without them.\n'
+        )
+        user_input = input(f'Do you want to include handles of your followers '
+                           f'in the online lookup of user handles anyway? [Y/n]')
+        if user_input.lower() in ['n', 'no']:
+            collected_user_ids = collected_user_ids_without_followers
 
     lookup_users(collected_user_ids, users)
 

--- a/parser.py
+++ b/parser.py
@@ -408,13 +408,14 @@ def convert_tweet(tweet, username, media_sources, users: dict, paths: PathConfig
         if int(reply_to_id) >= 0:  # some ids are -1, not sure why
             handle = tweet['in_reply_to_screen_name']
             users[reply_to_id] = UserData(user_id=reply_to_id, handle=handle)
-    if 'entities' in tweet and 'user_mentions' in tweet['entities']:
+    if 'entities' in tweet and 'user_mentions' in tweet['entities'] and tweet['entities']['user_mentions'] is not None:
         for mention in tweet['entities']['user_mentions']:
-            mentioned_id = mention['id']
-            if int(mentioned_id) >= 0:  # some ids are -1, not sure why
-                handle = mention['screen_name']
-                if handle is not None:
-                    users[mentioned_id] = UserData(user_id=mentioned_id, handle=handle)
+            if mention is not None and 'id' in mention and 'screen_name' in mention:
+                mentioned_id = mention['id']
+                if int(mentioned_id) >= 0:  # some ids are -1, not sure why
+                    handle = mention['screen_name']
+                    if handle is not None:
+                        users[mentioned_id] = UserData(user_id=mentioned_id, handle=handle)
 
     return timestamp, body_markdown, body_html
 

--- a/parser.py
+++ b/parser.py
@@ -46,14 +46,38 @@ class UserData:
         self.handle = handle
 
 
+def get_consent(prompt: str, default_to_yes: bool = False):
+    """Asks the user for consent, using the given prompt. Accepts various versions of yes/no, or 
+    an empty answer to accept the default. The default is 'no' unless default_to_yes is passed as 
+    True. The default will be indicated automatically. For unacceptable answers, the user will 
+    be asked again."""
+    if default_to_yes:
+        suffix = " [Y/n]"
+        default_answer = "yes"
+    else:
+        suffix = " [y/N]"
+        default_answer = "no"
+    while True:
+        user_input = input(prompt + suffix)
+        if user_input == "":
+            print (f"Your empty response was assumed to mean '{default_answer}' (the default for this question).")
+            return default_to_yes
+        if user_input.lower() in ('y', 'yes'):
+            return True
+        if user_input.lower() in ('n', 'no'):
+            return False
+        print (f"Sorry, did not understand. Please answer with y, n, yes, no, or press enter to accept "
+            f"the default (which is '{default_answer}' in this case, as indicated by the uppercase "
+            f"'{default_answer.upper()[0]}'.)")
+
+
 def import_module(module):
     """Imports a module specified by a string. Example: requests = import_module('requests')"""
     try:
         return importlib.import_module(module)
     except ImportError:
         print(f'\nError: This script uses the "{module}" module which is not installed.\n')
-        user_input = input('OK to install using pip? [y/n]')
-        if not user_input.lower() in ('y', 'yes'):
+        if not get_consent('OK to install using pip?'):
             exit()
         subprocess.run([sys.executable, '-m', 'pip', 'install', module], check=True)
         return importlib.import_module(module)
@@ -102,9 +126,9 @@ def lookup_users(user_ids, users):
     # Account metadata observed at ~2.1KB on average.
     estimated_size = int(2.1 * len(filtered_user_ids))
     print(f'{len(filtered_user_ids)} users are unknown.')
-    user_input = input(f'Download user data from Twitter (approx {estimated_size:,}KB)? [y/n]')
-    if user_input.lower() not in ('y', 'yes'):
+    if not get_consent(f'Download user data from Twitter (approx {estimated_size:,}KB)?'):
         return
+
     requests = import_module('requests')
     try:
         with requests.Session() as session:
@@ -1084,9 +1108,9 @@ def main():
     print(f'Please be aware that this script may download a lot of data, which will cost you money if you are')
     print(f'paying for bandwidth. Please be aware that the servers might block these requests if they are too')
     print(f'frequent. This script may not work if your account is protected. You may want to set it to public')
-    print(f'before starting the download.')
-    user_input = input('\nOK to start downloading? [y/n]')
-    if user_input.lower() in ('y', 'yes'):
+    print(f'before starting the download.\n')
+
+    if get_consent('OK to start downloading?'):
         download_larger_media(media_sources, paths)
         print('In case you set your account to public before initiating the download, do not forget to protect it again.')
 

--- a/parser.py
+++ b/parser.py
@@ -776,13 +776,13 @@ def download_larger_media(media_sources: dict, paths: PathConfig):
     while remaining_tries > 0:
         number_of_files = len(media_sources)
         success_count = 0
-        retries = []
+        retries = {}
         for index, (local_media_path, media_url) in enumerate(media_sources.items()):
             success, bytes_downloaded = download_file_if_larger(media_url, local_media_path, index + 1, number_of_files, sleep_time)
             if success:
                 success_count += 1
             else:
-                retries.append((local_media_path, media_url))
+                retries[local_media_path] = media_url
             total_bytes_downloaded += bytes_downloaded
 
             # show % done and estimated remaining time:

--- a/parser.py
+++ b/parser.py
@@ -116,6 +116,7 @@ def lookup_users(user_ids, users):
     except Exception as err:
         print(f'Failed to download user data: {err}')
 
+
 def read_json_from_js_file(filename):
     """Reads the contents of a Twitter-produced .js file into a dictionary."""
     print(f'Parsing {filename}...')
@@ -688,17 +689,17 @@ def main():
 
     following_ids = collect_user_ids_from_followings(paths)
     print(f'found {len(following_ids)} user IDs in followings.')
-    lookup_users(following_ids, users)
-    parse_followings(users, URL_template_user_id, paths)
-
     follower_ids = collect_user_ids_from_followers(paths)
     print(f'found {len(follower_ids)} user IDs in followers.')
-    lookup_users(follower_ids, users)
-    parse_followers(users, URL_template_user_id, paths)
-
     dms_user_ids = collect_user_ids_from_direct_messages(paths)
     print(f'found {len(dms_user_ids)} user IDs in direct messages.')
-    lookup_users(dms_user_ids, users)
+
+    # bulk lookup for user handles from followers, followings and direct messages
+    collected_user_ids = list(set(following_ids).union(set(follower_ids)).union(set(dms_user_ids)))
+    lookup_users(collected_user_ids, users)
+
+    parse_followings(users, URL_template_user_id, paths)
+    parse_followers(users, URL_template_user_id, paths)
     parse_direct_messages(username, users, URL_template_user_id, paths)
 
     # Download larger images, if the user agrees

--- a/parser.py
+++ b/parser.py
@@ -172,17 +172,21 @@ def convert_tweet(tweet, username, media_sources, users, paths):
     # added to the urls entities list so that we can build correct links later on.
     if 'entities' in tweet and 'media' not in tweet['entities'] and len(tweet['entities'].get("urls", [])) == 0:
         for word in tweet['full_text'].split():
-            url = urlparse(word)
-            if url.scheme != '' and url.netloc != '' and not word.endswith('\u2026'):
-                # Shorten links similiar to twitter
-                netloc_short = url.netloc[4:] if url.netloc.startswith("www.") else url.netloc
-                path_short = url.path if len(url.path + '?' + url.query) < 15 else (url.path + '?' + url.query)[:15] + '\u2026'
-                tweet['entities']['urls'].append({
-                    'url': word,
-                    'expanded_url': word,
-                    'display_url': netloc_short + path_short,
-                    'indices': [tweet['full_text'].index(word), tweet['full_text'].index(word) + len(word)],
-                })
+            try:
+                url = urlparse(word)
+            except ValueError:
+                pass  # don't crash when trying to parse something that looks like a URL but actually isn't
+            else:
+                if url.scheme != '' and url.netloc != '' and not word.endswith('\u2026'):
+                    # Shorten links similiar to twitter
+                    netloc_short = url.netloc[4:] if url.netloc.startswith("www.") else url.netloc
+                    path_short = url.path if len(url.path + '?' + url.query) < 15 else (url.path + '?' + url.query)[:15] + '\u2026'
+                    tweet['entities']['urls'].append({
+                        'url': word,
+                        'expanded_url': word,
+                        'display_url': netloc_short + path_short,
+                        'indices': [tweet['full_text'].index(word), tweet['full_text'].index(word) + len(word)],
+                    })
     # replace t.co URLs with their original versions
     if 'entities' in tweet and 'urls' in tweet['entities']:
         for url in tweet['entities']['urls']:

--- a/parser.py
+++ b/parser.py
@@ -1550,13 +1550,13 @@ def migrate_old_output(paths: PathConfig):
         print("which were probably generated from an older version of this script.")
         print("Since then, the directory layout of twitter-archive-parser has changed")
         print("and these files are generated into the sub-directory 'parser-output' or")
-        print("various sub-sub-directories therein. These are the affected files:")
+        print("various sub-sub-directories therein. These are the affected files:\n")
 
         for file_to_delete in files_to_delete:
             print(file_to_delete)
 
-        user_input = input('\nOK delete these files? (If the the directory layout would not have changed, they would be overwritten anyway) [y/N]')
-        if user_input.lower() in ('y', 'yes'):
+        print()
+        if get_consent('OK to delete these files? (If the the directory layout would not have changed, they would be overwritten anyway)'):
             for file_to_delete in files_to_delete:
                 os.remove(file_to_delete)
             print(f"Files have been deleted. New versions of these files will be generated into 'parser-output' soon.")
@@ -1648,16 +1648,17 @@ def main():
     parse_group_direct_messages(username, users, user_id_url_template, paths)
 
     # Download larger images, if the user agrees
-    print(f"\nThe archive doesn't contain the original-size images. We can attempt to download them from twimg.com.")
-    print(f'Please be aware that this script may download a lot of data, which will cost you money if you are')
-    print(f'paying for bandwidth. Please be aware that the servers might block these requests if they are too')
-    print(f'frequent. This script may not work if your account is protected. You may want to set it to public')
-    print(f'before starting the download.\n')
+    if len(media_sources) > 0:
+        print(f"\nThe archive doesn't contain the original-size images. We can attempt to download them from twimg.com.")
+        print(f'Please be aware that this script may download a lot of data, which will cost you money if you are')
+        print(f'paying for bandwidth. Please be aware that the servers might block these requests if they are too')
+        print(f'frequent. This script may not work if your account is protected. You may want to set it to public')
+        print(f'before starting the download.\n')
 
-    if get_consent('OK to start downloading?'):
-        download_larger_media(media_sources, paths)
-        print('In case you set your account to public before initiating the download, '
-              'do not forget to protect it again.')
+        if get_consent('OK to start downloading {len(media_sources)} media files?'):
+            download_larger_media(media_sources, log_path)
+            print('In case you set your account to public before initiating the download, '
+                'do not forget to protect it again.')
 
 
 if __name__ == "__main__":

--- a/parser.py
+++ b/parser.py
@@ -442,6 +442,32 @@ def download_larger_media(media_sources, paths):
             else:
                 retries.append((local_media_path, media_url))
             total_bytes_downloaded += bytes_downloaded
+
+            # show % done and estimated remaining time:
+            time_elapsed: float = time.time() - start_time
+            estimated_time_per_file: float = time_elapsed / (index + 1)
+            estimated_time_remaining: datetime.datetime = \
+                datetime.datetime.fromtimestamp(
+                    (number_of_files - (index + 1)) * estimated_time_per_file,
+                    tz=datetime.timezone.utc
+                )
+            if estimated_time_remaining.hour >= 1:
+                time_remaining_string: str = \
+                    f"{estimated_time_remaining.hour} hour{'' if estimated_time_remaining.hour == 1 else 's'} " \
+                    f"{estimated_time_remaining.minute} minute{'' if estimated_time_remaining.minute == 1 else 's'}"
+            elif estimated_time_remaining.minute >= 1:
+                time_remaining_string: str = \
+                    f"{estimated_time_remaining.minute} minute{'' if estimated_time_remaining.minute == 1 else 's'} " \
+                    f"{estimated_time_remaining.second} second{'' if estimated_time_remaining.second == 1 else 's'}"
+            else:
+                time_remaining_string: str = \
+                    f"{estimated_time_remaining.second} second{'' if estimated_time_remaining.second == 1 else 's'}"
+
+            if index + 1 == number_of_files:
+                print('    100 % done.')
+            else:
+                print(f'    {(100*(index+1)/number_of_files):.1f} % done, about {time_remaining_string} remaining...')
+
         media_sources = retries
         remaining_tries -= 1
         sleep_time += 2

--- a/parser.py
+++ b/parser.py
@@ -453,7 +453,7 @@ def parse_tweets(username, users, html_template, paths):
 
     for filename, content in grouped_tweets.items():
         # Write into *.md files
-        md_string =  '\n\n----\n\n'.join(md for md, _ in content)
+        md_string = '\n\n----\n\n'.join(md for md, _ in content)
         with open(f'{filename}.md', 'w', encoding='utf-8') as f:
             f.write(md_string)
 
@@ -551,6 +551,8 @@ def parse_direct_messages(username, users, URL_template_user_id, paths):
                                     if 'url' in url and 'expanded' in url:
                                         expanded_url = url['expanded']
                                         body = body.replace(url['url'], expanded_url)
+                            # escape message body for markdown rendering:
+                            body_markdown = escape_markdown(body)
                             # replace image URLs with image links to local files
                             if 'mediaUrls' in message_create \
                                     and len(message_create['mediaUrls']) == 1 \
@@ -568,7 +570,9 @@ def parse_direct_messages(username, users, URL_template_user_id, paths):
                                     if not os.path.isfile(new_url):
                                         shutil.copy(archive_media_path, new_url)
                                     image_markdown = f'\n![]({new_url})\n'
-                                    body = body.replace(original_expanded_url, image_markdown)
+                                    body_markdown = body_markdown.replace(
+                                        escape_markdown(original_expanded_url), image_markdown
+                                    )
 
                                     # Save the online location of the best-quality version of this file,
                                     # for later upgrading if wanted
@@ -599,7 +603,9 @@ def parse_direct_messages(username, users, URL_template_user_id, paths):
                                                 shutil.copy(archive_media_path, media_url)
                                             video_markdown = f'\n<video controls><source src="{media_url}">' \
                                                              f'Your browser does not support the video tag.</video>\n'
-                                            body = body.replace(original_expanded_url, video_markdown)
+                                            body_markdown = body_markdown.replace(
+                                                escape_markdown(original_expanded_url), video_markdown
+                                            )
 
                                     # TODO: maybe  also save the online location of the best-quality version for videos?
                                     #  (see above)
@@ -612,13 +618,15 @@ def parse_direct_messages(username, users, URL_template_user_id, paths):
                             timestamp = \
                                 int(round(datetime.datetime.strptime(created_at, '%Y-%m-%dT%X.%fZ').timestamp()))
 
-                            from_handle = users[from_id].handle.replace('_', '\\_') if from_id in users \
+                            from_handle = escape_markdown(users[from_id].handle) if from_id in users \
                                 else URL_template_user_id.format(from_id)
-                            to_handle = users[to_id].handle.replace('_', '\\_') if to_id in users \
+                            to_handle = escape_markdown(users[to_id].handle) if to_id in users \
                                 else URL_template_user_id.format(to_id)
 
-                            message_markdown = f'\n\n### {from_handle} -> {to_handle}: ' \
-                                               f'({created_at}) ###\n```\n{body}\n```'
+                            # make the body a quote
+                            body_markdown = '> ' + '\n> '.join(body_markdown.splitlines())
+                            message_markdown = f'{from_handle} -> {to_handle}: ({created_at}) \n\n' \
+                                               f'{body_markdown}'
                             messages.append((timestamp, message_markdown))
 
             # find identifier for the conversation
@@ -634,12 +642,12 @@ def parse_direct_messages(username, users, URL_template_user_id, paths):
         # sort messages by timestamp
         messages.sort(key=lambda tup: tup[0])
 
-        other_user_name = users[other_user_id].handle.replace('_', '\\_') if other_user_id in users \
+        other_user_name = escape_markdown(users[other_user_id].handle) if other_user_id in users \
             else URL_template_user_id.format(other_user_id)
 
         other_user_short_name: str = users[other_user_id].handle if other_user_id in users else other_user_id
 
-        escaped_username = username.replace('_', '\\_')
+        escaped_username = escape_markdown(username)
 
         # if there are more than 1000 messages, the conversation was split up in the twitter archive.
         # following this standard, also split up longer conversations in the output files:
@@ -647,9 +655,9 @@ def parse_direct_messages(username, users, URL_template_user_id, paths):
         if len(messages) > 1000:
             for chunk_index, chunk in enumerate(chunks(messages, 1000)):
                 markdown = ''
-                markdown += f'## Conversation between {escaped_username} and {other_user_name}, ' \
-                            f'part {chunk_index+1}: ##\n'
-                markdown += ''.join(md for _, md in chunk)
+                markdown += f'### Conversation between {escaped_username} and {other_user_name}, ' \
+                            f'part {chunk_index+1}: ###\n\n----\n\n'
+                markdown += '\n\n----\n\n'.join(md for _, md in chunk)
                 conversation_output_filename = \
                     paths.file_template_dm_output.format(f'{other_user_short_name}_part{chunk_index+1:03}')
 
@@ -661,8 +669,8 @@ def parse_direct_messages(username, users, URL_template_user_id, paths):
 
         else:
             markdown = ''
-            markdown += f'## Conversation between {escaped_username} and {other_user_name}: ##\n'
-            markdown += ''.join(md for _, md in messages)
+            markdown += f'### Conversation between {escaped_username} and {other_user_name}: ###\n\n----\n\n'
+            markdown += '\n\n----\n\n'.join(md for _, md in messages)
             conversation_output_filename = paths.file_template_dm_output.format(other_user_short_name)
 
             with open(conversation_output_filename, 'w', encoding='utf8') as f:
@@ -778,6 +786,8 @@ def parse_group_direct_messages(username, users, user_id_url_template, paths):
                                     if 'url' in url and 'expanded' in url:
                                         expanded_url = url['expanded']
                                         body = body.replace(url['url'], expanded_url)
+                            # escape message body for markdown rendering:
+                            body_markdown = escape_markdown(body)
                             # replace image URLs with image links to local files
                             if 'mediaUrls' in message_create \
                                     and len(message_create['mediaUrls']) == 1 \
@@ -796,7 +806,9 @@ def parse_group_direct_messages(username, users, user_id_url_template, paths):
                                     if not os.path.isfile(new_url):
                                         shutil.copy(archive_media_path, new_url)
                                     image_markdown = f'\n![]({new_url})\n'
-                                    body = body.replace(original_expanded_url, image_markdown)
+                                    body_markdown = body_markdown.replace(
+                                        escape_markdown(original_expanded_url), image_markdown
+                                    )
 
                                     # Save the online location of the best-quality version of this file,
                                     # for later upgrading if wanted
@@ -829,7 +841,9 @@ def parse_group_direct_messages(username, users, user_id_url_template, paths):
                                                 shutil.copy(archive_media_path, media_url)
                                             video_markdown = f'\n<video controls><source src="{media_url}">' \
                                                              f'Your browser does not support the video tag.</video>\n'
-                                            body = body.replace(original_expanded_url, video_markdown)
+                                            body_markdown = body_markdown.replace(
+                                                escape_markdown(original_expanded_url), video_markdown
+                                            )
 
                                     # TODO: maybe  also save the online location of the best-quality version for videos?
                                     #  (see above)
@@ -841,22 +855,25 @@ def parse_group_direct_messages(username, users, user_id_url_template, paths):
                             timestamp = int(round(
                                 datetime.datetime.strptime(created_at, '%Y-%m-%dT%X.%fZ').timestamp()
                             ))
-                            from_handle = users[from_id].handle.replace('_', '\\_') if from_id in users \
+                            from_handle = escape_markdown(users[from_id].handle) if from_id in users \
                                 else user_id_url_template.format(from_id)
-                            message_markdown = f'\n\n### {from_handle}: ({created_at}) ###\n```\n{body}\n```'
+                            # make the body a quote
+                            body_markdown = '> ' + '\n> '.join(body_markdown.splitlines())
+                            message_markdown = f'{from_handle}: ({created_at})\n\n' \
+                                               f'{body_markdown}'
                             messages.append((timestamp, message_markdown))
                     elif "conversationNameUpdate" in message:
                         conversation_name_update = message['conversationNameUpdate']
                         if all(tag in conversation_name_update for tag in ['initiatingUserId', 'name', 'createdAt']):
                             from_id = conversation_name_update['initiatingUserId']
-                            body = f"_changed group name to: {conversation_name_update['name']}_"
+                            body_markdown = f"_changed group name to: {escape_markdown(conversation_name_update['name'])}_"
                             created_at = conversation_name_update['createdAt']  # example: 2022-01-27T15:58:52.744Z
                             timestamp = int(round(
                                 datetime.datetime.strptime(created_at, '%Y-%m-%dT%X.%fZ').timestamp()
                             ))
-                            from_handle = users[from_id].handle.replace('_', '\\_') if from_id in users \
+                            from_handle = escape_markdown(users[from_id].handle) if from_id in users \
                                 else user_id_url_template.format(from_id)
-                            message_markdown = f'\n\n### {from_handle}: ({created_at}) ###\n\n{body}\n'
+                            message_markdown = f'{from_handle}: ({created_at})\n\n{body_markdown}'
                             messages.append((timestamp, message_markdown))
                             # save metadata about name change:
                             group_conversations_metadata[conversation_id]['conversation_names'].append(
@@ -870,11 +887,11 @@ def parse_group_direct_messages(username, users, user_id_url_template, paths):
                             timestamp = int(round(
                                 datetime.datetime.strptime(created_at, '%Y-%m-%dT%X.%fZ').timestamp()
                             ))
-                            from_handle = users[from_id].handle.replace('_', '\\_') if from_id in users \
+                            from_handle = escape_markdown(users[from_id].handle) if from_id in users \
                                 else user_id_url_template.format(from_id)
-                            escaped_username = username.replace('_', '\\_')
-                            body = f'_{from_handle} added {escaped_username} to the group_'
-                            message_markdown = f'\n\n### {from_handle}: ({created_at}) ###\n\n{body}\n'
+                            escaped_username = escape_markdown(username)
+                            body_markdown = f'_{from_handle} added {escaped_username} to the group_'
+                            message_markdown = f'{from_handle}: ({created_at})\n\n{body_markdown}'
                             messages.append((timestamp, message_markdown))
                     elif "participantsJoin" in message:
                         participants_join = message['participantsJoin']
@@ -884,16 +901,16 @@ def parse_group_direct_messages(username, users, user_id_url_template, paths):
                             timestamp = int(round(
                                 datetime.datetime.strptime(created_at, '%Y-%m-%dT%X.%fZ').timestamp()
                             ))
-                            from_handle = users[from_id].handle.replace('_', '\\_') if from_id in users \
+                            from_handle = escape_markdown(users[from_id].handle) if from_id in users \
                                 else user_id_url_template.format(from_id)
                             joined_ids = participants_join['userIds']
-                            joined_handles = [users[joined_id].handle.replace('_', '\\_') if joined_id in users
+                            joined_handles = [escape_markdown(users[joined_id].handle) if joined_id in users
                                               else user_id_url_template.format(joined_id) for joined_id in joined_ids]
                             name_list = ', '.join(joined_handles[:-1]) + \
                                         (f' and {joined_handles[-1]}' if len(joined_handles) > 1 else
                                          joined_handles[0])
-                            body = f'_{from_handle} added {name_list} to the group_'
-                            message_markdown = f'\n\n### {from_handle}: ({created_at}) ###\n\n{body}\n'
+                            body_markdown = f'_{from_handle} added {name_list} to the group_'
+                            message_markdown = f'{from_handle}: ({created_at})\n\n{body_markdown}'
                             messages.append((timestamp, message_markdown))
                     elif "participantsLeave" in message:
                         participants_leave = message['participantsLeave']
@@ -903,13 +920,13 @@ def parse_group_direct_messages(username, users, user_id_url_template, paths):
                                 datetime.datetime.strptime(created_at, '%Y-%m-%dT%X.%fZ').timestamp()
                             ))
                             left_ids = participants_leave['userIds']
-                            left_handles = [users[left_id].handle.replace('_', '\\_') if left_id in users
+                            left_handles = [escape_markdown(users[left_id].handle) if left_id in users
                                             else user_id_url_template.format(left_id) for left_id in left_ids]
                             name_list = ', '.join(left_handles[:-1]) + \
                                         (f' and {left_handles[-1]}' if len(left_handles) > 1 else
                                          left_handles[0])
-                            body = f'_{name_list} left the group_'
-                            message_markdown = f'\n\n### {name_list}: ({created_at}) ###\n\n{body}\n'
+                            body_markdown = f'_{name_list} left the group_'
+                            message_markdown = f'{name_list}: ({created_at})\n\n{body_markdown}'
                             messages.append((timestamp, message_markdown))
 
             # collect messages per conversation in group_conversations_messages dict
@@ -966,7 +983,7 @@ def parse_group_direct_messages(username, users, user_id_url_template, paths):
         # create a list of names of the form '@name1, @name2 and @name3'
         # to use as a headline in the output file
         escaped_participant_names = [
-            participant_name.replace('_', '\\_')
+            escape_markdown(participant_name)
             for participant_name in group_conversations_metadata[conversation_id]['participant_names']
         ]
         name_list = ', '.join(escaped_participant_names[:-1]) + \
@@ -977,9 +994,9 @@ def parse_group_direct_messages(username, users, user_id_url_template, paths):
         if len(messages) > 1000:
             for chunk_index, chunk in enumerate(chunks(messages, 1000)):
                 markdown = ''
-                markdown += f'# {official_name}\n'
-                markdown += f'## Group conversation between {name_list}, part {chunk_index + 1}: ##\n'
-                markdown += ''.join(md for _, md in chunk)
+                markdown += f'## {official_name} ##\n\n'
+                markdown += f'### Group conversation between {name_list}, part {chunk_index + 1}: ###\n\n----\n\n'
+                markdown += '\n\n----\n\n'.join(md for _, md in chunk)
                 conversation_output_filename = \
                     paths.file_template_group_dm_output.format(f'{group_name}_part{chunk_index + 1:03}')
 
@@ -990,9 +1007,9 @@ def parse_group_direct_messages(username, users, user_id_url_template, paths):
                 num_written_files += 1
         else:
             markdown = ''
-            markdown += f'# {official_name}\n'
-            markdown += f'## Group conversation between {name_list}: ##\n'
-            markdown += ''.join(md for _, md in messages)
+            markdown += f'## {official_name} ##\n\n'
+            markdown += f'### Group conversation between {name_list}: ###\n\n----\n\n'
+            markdown += '\n\n----\n\n'.join(md for _, md in messages)
             conversation_output_filename = paths.file_template_group_dm_output.format(group_name)
 
             with open(conversation_output_filename, 'w', encoding='utf8') as f:

--- a/parser.py
+++ b/parser.py
@@ -101,7 +101,7 @@ def lookup_users(user_ids, users):
         return
     # Account metadata observed at ~2.1KB on average.
     estimated_size = int(2.1 * len(filtered_user_ids))
-    print(f'{len(filtered_user_ids)} users are unknown.')
+    print(f'\n{len(filtered_user_ids)} users are unknown.')
     user_input = input(f'Download user data from Twitter (approx {estimated_size:,}KB)? [y/n]')
     if user_input.lower() not in ('y', 'yes'):
         return
@@ -113,6 +113,7 @@ def lookup_users(user_ids, users):
             retrieved_users = get_twitter_users(session, bearer_token, guest_token, filtered_user_ids)
             for user_id, user in retrieved_users.items():
                 users[user_id] = UserData(user_id, user["screen_name"])
+        print()  # empty line for better readability of output
     except Exception as err:
         print(f'Failed to download user data: {err}')
 

--- a/parser.py
+++ b/parser.py
@@ -1236,9 +1236,9 @@ def main():
             f'about {estimated_follower_lookup_size:,} KB smaller and up to '
             f'{estimated_max_follower_lookup_time_in_minutes:.1f} minutes faster without them.\n'
         )
-        user_input = input(f'Do you want to include handles of your followers '
-                           f'in the online lookup of user handles anyway? [Y/n]')
-        if user_input.lower() in ['n', 'no']:
+
+        if not get_consent(f'Do you want to include handles of your followers '
+                           f'in the online lookup of user handles anyway?', default_to_yes=True):
             collected_user_ids = collected_user_ids_without_followers
 
     lookup_users(collected_user_ids, users)

--- a/parser.py
+++ b/parser.py
@@ -210,6 +210,10 @@ def merge(a, b, path=None):
         if key in a:
             if isinstance(a[key], dict) and isinstance(b[key], dict):
                 merge(a[key], b[key], path + [str(key)])
+            elif isinstance(a[key], list) and isinstance(b[key], list):
+                for item_b in b[key]:
+                    if item_b not in a[key]:
+                        a[key].append(item_b)
             elif a[key] == b[key]:
                 pass # same leaf value
             elif key == 'retweet_count' or key == 'favorite_count':


### PR DESCRIPTION
Here's some work which I already did 3 days ago, but had not made into a PR before.

Yesterday I incorporated the newest stuff from `timhutton/twitter-archive-parser/main` into both `timhutton/twitter-archive-parser/downloadtweets` and  `lenaschimmel/twitter-archive-parser/downloadtweets` because I thought that would make it easier to keep everything up to date and focus on the actual (non-merge) commits.

## What's actually included
This is just more WIP on the *download tweets* feature:

 * Error handling in `get_tweets` - if it fails, return the tweets we already downloaded, plus the ids of tweets that are still missing
 * Add `merge` method, which can basically merge all kinds of python values, but contains some special treatments for dicts representing tweets. This should make sure that if a tweet is contained in the archive, and we download that same tweet via the API, we can merge them without losing any information.
 * add helper method `has_path` which simplifies those chained checks that we have all over the code, like: `if 'entities' in tweet and 'user_mentions' in tweet['entities'] and tweet['entities']['user_mentions'] is not None`
 * save downloaded tweets into `known_tweets.json`, and load them on next script execution, so that we don't reload the same tweets over and over again.
 * annotate downloaded tweets with attributes like `from_api`, `download_with_user`, `download_with_alt_text` so that `collect_tweet_references` can make better decisions on what do re-download, and whether to follow references or not
 * improved merging and comparing of tweet JSON objects. Those are some really nasty data structures!