### PR TITLE
More consistent / robust questions for consent

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -46,14 +46,38 @@ class UserData:
         self.handle = handle
 
 
+def get_consent(prompt: str, default_to_yes: bool = False):
+    """Asks the user for consent, using the given prompt. Accepts various versions of yes/no, or 
+    an empty answer to accept the default. The default is 'no' unless default_to_yes is passed as 
+    True. The default will be indicated automatically. For unacceptable answers, the user will 
+    be asked again."""
+    if default_to_yes:
+        suffix = " [Y/n]"
+        default_answer = "yes"
+    else:
+        suffix = " [y/N]"
+        default_answer = "no"
+    while True:
+        user_input = input(prompt + suffix)
+        if user_input == "":
+            print (f"Your empty response was assumed to mean '{default_answer}' (the default for this question).")
+            return default_to_yes
+        if user_input.lower() in ('y', 'yes'):
+            return True
+        if user_input.lower() in ('n', 'no'):
+            return False
+        print (f"Sorry, did not understand. Please answer with y, n, yes, no, or press enter to accept "
+            f"the default (which is '{default_answer}' in this case, as indicated by the uppercase "
+            f"'{default_answer.upper()[0]}'.)")
+
+
 def import_module(module):
     """Imports a module specified by a string. Example: requests = import_module('requests')"""
     try:
         return importlib.import_module(module)
     except ImportError:
         print(f'\nError: This script uses the "{module}" module which is not installed.\n')
-        user_input = input('OK to install using pip? [y/n]')
-        if not user_input.lower() in ('y', 'yes'):
+        if not get_consent('OK to install using pip?'):
             exit()
         subprocess.run([sys.executable, '-m', 'pip', 'install', module], check=True)
         return importlib.import_module(module)
@@ -102,9 +126,9 @@ def lookup_users(user_ids, users):
     # Account metadata observed at ~2.1KB on average.
     estimated_size = int(2.1 * len(filtered_user_ids))
     print(f'{len(filtered_user_ids)} users are unknown.')
-    user_input = input(f'Download user data from Twitter (approx {estimated_size:,}KB)? [y/n]')
-    if user_input.lower() not in ('y', 'yes'):
+    if not get_consent(f'Download user data from Twitter (approx {estimated_size:,}KB)?'):
         return
+
     requests = import_module('requests')
     try:
         with requests.Session() as session:
@@ -1084,9 +1108,9 @@ def main():
     print(f'Please be aware that this script may download a lot of data, which will cost you money if you are')
     print(f'paying for bandwidth. Please be aware that the servers might block these requests if they are too')
     print(f'frequent. This script may not work if your account is protected. You may want to set it to public')
-    print(f'before starting the download.')
-    user_input = input('\nOK to start downloading? [y/n]')
-    if user_input.lower() in ('y', 'yes'):
+    print(f'before starting the download.\n')
+
+    if get_consent('OK to start downloading?'):
         download_larger_media(media_sources, paths)
         print('In case you set your account to public before initiating the download, do not forget to protect it again.')
 

--- a/parser.py
+++ b/parser.py
@@ -1236,9 +1236,9 @@ def main():
             f'about {estimated_follower_lookup_size:,} KB smaller and up to '
             f'{estimated_max_follower_lookup_time_in_minutes:.1f} minutes faster without them.\n'
         )
-        user_input = input(f'Do you want to include handles of your followers '
-                           f'in the online lookup of user handles anyway? [Y/n]')
-        if user_input.lower() in ['n', 'no']:
+
+        if not get_consent(f'Do you want to include handles of your followers '
+                           f'in the online lookup of user handles anyway?', default_to_yes=True):
             collected_user_ids = collected_user_ids_without_followers
 
     lookup_users(collected_user_ids, users)


### PR DESCRIPTION
Add method `get_consent` which ensures that yes/no questions are displayed consistently, users know what the default is, and unexpected inputs are handled more robustly.

(in the current `main`, there are only three places where it is used, but I think that the current and future PRs will add more cases in which consent is required.)

Example output with some context:
```
Parsing ./data/following.js...
31 users are unknown.
Download user data from Twitter (approx 65KB)? [y/N]b
Sorry, did not understand. Please answer with y, n, yes, no, or press enter to accept the default (which
is 'no' in this case, as indicated by the uppercase 'N'.)
Download user data from Twitter (approx 65KB)? [y/N]
Your empty response was assumed to mean 'no' (the default for this question).
Wrote 48 accounts to ./following.txt
```