### PR TITLE
show % done and estimated remaining time for media downloads

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -442,6 +442,32 @@ def download_larger_media(media_sources, paths):
             else:
                 retries.append((local_media_path, media_url))
             total_bytes_downloaded += bytes_downloaded
+
+            # show % done and estimated remaining time:
+            time_elapsed: float = time.time() - start_time
+            estimated_time_per_file: float = time_elapsed / (index + 1)
+            estimated_time_remaining: datetime.datetime = \
+                datetime.datetime.fromtimestamp(
+                    (number_of_files - (index + 1)) * estimated_time_per_file,
+                    tz=datetime.timezone.utc
+                )
+            if estimated_time_remaining.hour >= 1:
+                time_remaining_string: str = \
+                    f"{estimated_time_remaining.hour} hour{'' if estimated_time_remaining.hour == 1 else 's'} " \
+                    f"{estimated_time_remaining.minute} minute{'' if estimated_time_remaining.minute == 1 else 's'}"
+            elif estimated_time_remaining.minute >= 1:
+                time_remaining_string: str = \
+                    f"{estimated_time_remaining.minute} minute{'' if estimated_time_remaining.minute == 1 else 's'} " \
+                    f"{estimated_time_remaining.second} second{'' if estimated_time_remaining.second == 1 else 's'}"
+            else:
+                time_remaining_string: str = \
+                    f"{estimated_time_remaining.second} second{'' if estimated_time_remaining.second == 1 else 's'}"
+
+            if index + 1 == number_of_files:
+                print('    100 % done.')
+            else:
+                print(f'    {(100*(index+1)/number_of_files):.1f} % done, about {time_remaining_string} remaining...')
+
         media_sources = retries
         remaining_tries -= 1
         sleep_time += 2


### PR DESCRIPTION
Quick-and-dirty implementation of estimated time remaining for media downloads, as suggested in #127. The estimate is least accurate at the start, but gets a little better over time.

Example of how the output looks with this (filenames redacted):
```
...

OK to start downloading? [y/n]y
  1/2142 ./media/[FILENAME].jpg: SKIPPED. Online version is same byte size, assuming same content. Not downloaded.
    0.0 % done, about 8 minutes 46 seconds remaining...
  2/2142 ./media/[FILENAME].jpg: SKIPPED. Online version is same byte size, assuming same content. Not downloaded.
    0.1 % done, about 11 minutes 14 seconds remaining...
  3/2142 ./media/[FILENAME].jpg: SKIPPED. Online version is same byte size, assuming same content. Not downloaded.
    0.1 % done, about 11 minutes 59 seconds remaining...
  4/2142 ./media/[FILENAME].jpg: SKIPPED. Online version is same byte size, assuming same content. Not downloaded.
    0.2 % done, about 12 minutes 28 seconds remaining...
  5/2142 ./media/[FILENAME].jpg: SKIPPED. Online version is same byte size, assuming same content. Not downloaded.
    0.2 % done, about 12 minutes 38 seconds remaining...
  6/2142 ./media/[FILENAME].png: SKIPPED. Online version is same byte size, assuming same content. Not downloaded.
    0.3 % done, about 12 minutes 43 seconds remaining...
  7/2142 ./media/[FILENAME].jpg: SKIPPED. Online version is same byte size, assuming same content. Not downloaded.
    0.3 % done, about 12 minutes 48 seconds remaining...
  8/2142 ./media/[FILENAME].mp4: Requesting headers for https://video.twimg.com/ext_tw_video/[FILE_ID]/pu/vid/4  8/2142 ./media/[FILENAME].mp4: SKIPPED. Online version is same byte size, assuming same content. Not downloaded.
    0.4 % done, about 13 minutes 3 seconds remaining...
  9/2142 ./media/[FILENAME].jpg: SKIPPED. Online version is same byte size, assuming same content. Not downloaded.
    0.4 % done, about 13 minutes 0 seconds remaining...
 10/2142 ./media/[FILENAME].png: SKIPPED. Online version is same byte size, assuming same content. Not downloaded.
    0.5 % done, about 12 minutes 58 seconds remaining...
 11/2142 ./media/[FILENAME].jpg: FAIL. Media couldn't be retrieved from https://pbs.twimg.com/media/[FILENAME].jpg:orig because of exception: Download failed with status "404 Not Found". Response content: ""
    0.5 % done, about 13 minutes 18 seconds remaining...
 12/2142 ./media/[FILENAME].jpg: SKIPPED. Online version is same byte size, assuming same content. Not downloaded.
    0.6 % done, about 13 minutes 23 seconds remaining...
 13/2142 ./media/[FILENAME].jpg: SKIPPED. Online version is same byte size, assuming same content. Not downloaded.
    0.6 % done, about 13 minutes 20 seconds remaining...
    
...
```